### PR TITLE
Bugfixing spike exchange miniapp

### DIFF
--- a/neuromapp/coreneuron_1.0/event_passing/environment/generator.cpp
+++ b/neuromapp/coreneuron_1.0/event_passing/environment/generator.cpp
@@ -29,7 +29,7 @@ int ngroups, int rank, int nprocs, int ncells){
 
     //for the last rank, add the remaining cellgroups
     if(rank == (nprocs - 1))
-        cells_per = ngroups - start;
+        cells_per = ncells - start;
 
     double mean = static_cast<double>(simtime) / static_cast<double>(nSpikes);
     double lambda = 1.0 / static_cast<double>(mean * nprocs);

--- a/neuromapp/coreneuron_1.0/event_passing/environment/presyn_maker.cpp
+++ b/neuromapp/coreneuron_1.0/event_passing/environment/presyn_maker.cpp
@@ -25,7 +25,7 @@ void presyn_maker::operator()(int nprocs, int ngroups, int rank){
 
     //for last rank, add the leftover neurons
     if(rank == (nprocs - 1))
-        cells_per = ngroups - start;
+        cells_per = n_cells_ - start;
 
     int cur;
 

--- a/test/coreneuron_1.0/event_passing/queueing.cpp
+++ b/test/coreneuron_1.0/event_passing/queueing.cpp
@@ -204,6 +204,27 @@ BOOST_AUTO_TEST_CASE(pool_constructor){
     BOOST_CHECK(pl.get_ngroups() == ngroups);
 }
 
+ /**
+  * Tests the constructor for the generator class
+  * Specific set of parameters to elicit failure
+  * in commit 86f12a902962d16a227009ff1a0bb8ebe42a2e3
+  */
+ BOOST_AUTO_TEST_CASE(generator_constructor){
+     int ncells = 4;
+     int fanin = 4;
+     int ngroups = 1;
+     int nspikes = 100;
+     int rank = 1;
+     int nprocs = 2;
+
+     int simtime = 1;
+
+     environment::event_generator generator(nspikes, simtime, ngroups,
+     rank, nprocs, ncells);
+ }
+
+
+
 /**
  * Tests fixed_step function of the pool classi for one mindelay
  */


### PR DESCRIPTION
The logic for distributing cells across ranks is pretty straightforward: if I have a total of ncells to distribute over nprocs ranks, I simply assign ncells/nprocs cells to each one. 
This method requires special treatment for the "last rank": if ncells was not an exact multiple of nprocs, then I run the risk of not distributing all the cells correctly. Therefore, the number of cells belonging to the last rank is modified from ncells/nprocs to ncells - (nprocs-1)*ncells/nprocs. This could generate load imbalance, but it was not the scope of this bugfix to investigate that. 

What I observed in the previous version of the code was that, for some particular values of ncells, ngroups and nprocs an assertion would be raised. So I created a test that reproduces this error, tracked down the source of this assertion and fixed it!