### PR TITLE
Feature add different event generators

### DIFF
--- a/neuromapp/coreneuron_1.0/event_passing/CMakeLists.txt
+++ b/neuromapp/coreneuron_1.0/event_passing/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library (coreneuron10_environment environment/generator.cpp
 
 install (TARGETS coreneuron10_environment DESTINATION lib)
 install (FILES environment/generator.h
+	       environment/event_generators.hpp
                environment/presyn_maker.h DESTINATION include)
 
 

--- a/neuromapp/coreneuron_1.0/event_passing/drivers/distributed_driver.cpp
+++ b/neuromapp/coreneuron_1.0/event_passing/drivers/distributed_driver.cpp
@@ -33,6 +33,7 @@
 #include "coreneuron_1.0/event_passing/queueing/pool.h"
 #include "coreneuron_1.0/event_passing/queueing/thread.h"
 #include "coreneuron_1.0/event_passing/environment/generator.h"
+#include "coreneuron_1.0/event_passing/environment/event_generators.hpp"
 #include "coreneuron_1.0/event_passing/environment/presyn_maker.h"
 #include "coreneuron_1.0/event_passing/spike/spike_interface.h"
 #include "coreneuron_1.0/event_passing/spike/algos.hpp"
@@ -66,7 +67,14 @@ int main(int argc, char* argv[]) {
     int cellsper = ncells / size;
 
     //create environment
-    environment::event_generator generator(nSpikes, simtime, ngroups, rank, size, ncells);
+    environment::event_generator generator(ngroups);
+
+    double mean = static_cast<double>(simtime) / static_cast<double>(nSpikes);
+    double lambda = 1.0 / static_cast<double>(mean * size);
+
+    environment::generate_events_kai(generator.begin(), generator.end(),
+                              simtime, ngroups, rank, size, ncells, lambda);
+
     environment::presyn_maker presyns(ncells, fanin);
     presyns(size, ngroups, rank);
     spike::spike_interface s_interface(size);

--- a/neuromapp/coreneuron_1.0/event_passing/drivers/distributed_driver.cpp
+++ b/neuromapp/coreneuron_1.0/event_passing/drivers/distributed_driver.cpp
@@ -72,7 +72,7 @@ int main(int argc, char* argv[]) {
     double mean = static_cast<double>(simtime) / static_cast<double>(nSpikes);
     double lambda = 1.0 / static_cast<double>(mean * size);
 
-    environment::generate_events_kai(generator.begin(), generator.end(),
+    environment::generate_events_kai(generator.begin(),
                               simtime, ngroups, rank, size, ncells, lambda);
 
     environment::presyn_maker presyns(ncells, fanin);

--- a/neuromapp/coreneuron_1.0/event_passing/drivers/event.cpp
+++ b/neuromapp/coreneuron_1.0/event_passing/drivers/event.cpp
@@ -70,7 +70,7 @@ int main(int argc, char* argv[]) {
     double mean = static_cast<double>(simtime) / static_cast<double>(nSpikes);
     double lambda = 1.0 / static_cast<double>(mean * size);
 
-    environment::generate_events_kai(generator.begin(), generator.end(),
+    environment::generate_events_kai(generator.begin(),
                              simtime, ngroups, rank, size, ncells, lambda);
 
     environment::presyn_maker presyns(ncells, fanin);

--- a/neuromapp/coreneuron_1.0/event_passing/drivers/event.cpp
+++ b/neuromapp/coreneuron_1.0/event_passing/drivers/event.cpp
@@ -33,6 +33,7 @@
 #include "coreneuron_1.0/event_passing/queueing/pool.h"
 #include "coreneuron_1.0/event_passing/queueing/thread.h"
 #include "coreneuron_1.0/event_passing/environment/generator.h"
+#include "coreneuron_1.0/event_passing/environment/event_generators.hpp"
 #include "coreneuron_1.0/event_passing/environment/presyn_maker.h"
 #include "coreneuron_1.0/event_passing/spike/spike_interface.h"
 #include "coreneuron_1.0/event_passing/spike/algos.hpp"
@@ -64,7 +65,14 @@ int main(int argc, char* argv[]) {
     struct timeval start, end;
 
     //create environment
-    environment::event_generator generator(nSpikes, simtime, ngroups, rank, size, ncells);
+    environment::event_generator generator(ngroups);
+
+    double mean = static_cast<double>(simtime) / static_cast<double>(nSpikes);
+    double lambda = 1.0 / static_cast<double>(mean * size);
+
+    environment::generate_events_kai(generator.begin(), generator.end(),
+                             simtime, ngroups, rank, size, ncells, lambda);
+
     environment::presyn_maker presyns(ncells, fanin);
     presyns(size, ngroups, rank);
     spike::spike_interface s_interface(size);

--- a/neuromapp/coreneuron_1.0/event_passing/environment/event_generators.hpp
+++ b/neuromapp/coreneuron_1.0/event_passing/environment/event_generators.hpp
@@ -10,8 +10,25 @@
 
 namespace environment {
 
+    /** \fn void generate_events_kai(Iterator beg, int simtime, int ngroups, int rank, int nprocs, int ncells, double lambda)
+        \brief Kai's original implementation: generates events according to an exponential law.
+	\param Iterator beg
+    
+	This implementation generates an event per timestep, and attributes it to a random cell in the network. It then samples a survival interval using an exponential distribution, to determine when the next event will occur.
+	\warning this implementation lacks a biological implementation, since no two events can happen at the same time. This would imply that, in the whole network, only one cell fired at a time.
+
+
+
+
+    */
     template< typename Iterator >
-    void generate_events_kai(Iterator beg, Iterator end,  int simtime, int ngroups, int rank, int nprocs, int ncells, double lambda);
+    void generate_events_kai(Iterator beg, int simtime, int ngroups, int rank, int nprocs, int ncells, double lambda);
+
+    template< typename Iterator >
+    void generate_poisson_events(Iterator beg, int simtime, int ngroups, int rank, int nprocs, int ncells, double lambda);
+
+    template< typename Iterator >
+    void generate_uniform_events(Iterator beg, int simtime, int ngroups, int rank, int nprocs, int ncells, double firing_interval);
 
 }
 

--- a/neuromapp/coreneuron_1.0/event_passing/environment/event_generators.hpp
+++ b/neuromapp/coreneuron_1.0/event_passing/environment/event_generators.hpp
@@ -12,14 +12,16 @@ namespace environment {
 
     /** \fn void generate_events_kai(Iterator beg, int simtime, int ngroups, int rank, int nprocs, int ncells, double lambda)
         \brief Kai's original implementation: generates events according to an exponential law.
-	\param Iterator beg
-    
+	\param beg iterator to the beginning of the vector of queues of events.
+	\param simtime total time of simulation (in number of timesteps)
+	\param ngroups number of cellgroups per distributed rank
+	\param rank distributed rank number
+	\param nprocs the total number of distributed ranks in the whole simulation
+	\param ncells the total number of cells in the whole simulation
+	\param lambda the firing frequency (in num events/(timestep * rank)
+
 	This implementation generates an event per timestep, and attributes it to a random cell in the network. It then samples a survival interval using an exponential distribution, to determine when the next event will occur.
 	\warning this implementation lacks a biological implementation, since no two events can happen at the same time. This would imply that, in the whole network, only one cell fired at a time.
-
-
-
-
     */
     template< typename Iterator >
     void generate_events_kai(Iterator beg, int simtime, int ngroups, int rank, int nprocs, int ncells, double lambda);

--- a/neuromapp/coreneuron_1.0/event_passing/environment/event_generators.hpp
+++ b/neuromapp/coreneuron_1.0/event_passing/environment/event_generators.hpp
@@ -1,0 +1,20 @@
+#ifndef MAPP_ENV_GENERATORS_HPP
+#define MAPP_ENV_GENERATORS_HPP
+
+#include <boost/range/algorithm/random_shuffle.hpp>
+#include <boost/range/algorithm_ext/iota.hpp>
+#include <boost/random/mersenne_twister.hpp>
+#include <boost/random.hpp>
+
+#include "coreneuron_1.0/event_passing/environment/generator.h"
+
+namespace environment {
+
+    template< typename Iterator >
+    void generate_events_kai(Iterator beg, Iterator end,  int simtime, int ngroups, int rank, int nprocs, int ncells, double lambda);
+
+}
+
+#include "coreneuron_1.0/event_passing/environment/event_generators.ipp"
+
+#endif

--- a/neuromapp/coreneuron_1.0/event_passing/environment/event_generators.hpp
+++ b/neuromapp/coreneuron_1.0/event_passing/environment/event_generators.hpp
@@ -70,7 +70,7 @@ namespace environment {
     template< typename Iterator >
     void generate_poisson_events(Iterator beg, int simtime, int ngroups, int rank, int nprocs, int ncells, double lambda);
 
-    /** \fn void generate_uniform_events(Iterator beg, int simtime, int ngroups, int rank, int nprocs, int ncells, double firing_interval)
+    /** \fn void generate_uniform_events(Iterator beg, int simtime, int ngroups, int rank, int nprocs, int ncells, int firing_interval)
         \brief generates events based on a poisson distribution approximation.
 	\param beg iterator to the beginning of the vector of queues of events.
 	\param simtime total time of simulation (in number of timesteps)

--- a/neuromapp/coreneuron_1.0/event_passing/environment/event_generators.hpp
+++ b/neuromapp/coreneuron_1.0/event_passing/environment/event_generators.hpp
@@ -1,10 +1,39 @@
 #ifndef MAPP_ENV_GENERATORS_HPP
 #define MAPP_ENV_GENERATORS_HPP
 
+/*
+* Neuromapp - hines.c, Copyright (c), 2015,
+* Timothee Ewart - Swiss Federal Institute of technology in Lausanne,
+* Cremonesi Francesco - Swiss Federal Institute of technology in Lausanne,
+* timothee.ewart@epfl.ch,
+* francesco.cremonesi@epfl.ch
+* All rights reserved.
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public License
+* as published by the Free Software Foundation; either version 2
+* of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with this library.
+*/
+
+/**
+* @file neuromapp/coreneuron_1.0/event_passing/environment/event_generators.hpp
+* \brief Implements several functions for generating spike events
+*/
+
 #include <boost/range/algorithm/random_shuffle.hpp>
 #include <boost/range/algorithm_ext/iota.hpp>
 #include <boost/random/mersenne_twister.hpp>
 #include <boost/random.hpp>
+
+#include <cassert>
 
 #include "coreneuron_1.0/event_passing/environment/generator.h"
 
@@ -18,19 +47,44 @@ namespace environment {
 	\param rank distributed rank number
 	\param nprocs the total number of distributed ranks in the whole simulation
 	\param ncells the total number of cells in the whole simulation
-	\param lambda the firing frequency (in num events/(timestep * rank)
+	\param lambda the firing frequency of a single cell (in num events/timestep )
 
-	This implementation generates an event per timestep, and attributes it to a random cell in the network. It then samples a survival interval using an exponential distribution, to determine when the next event will occur.
-	\warning this implementation lacks a biological implementation, since no two events can happen at the same time. This would imply that, in the whole network, only one cell fired at a time.
+	This implementation generates an event per timestep, and attributes it to a random cell in the network. It then samples a survival interval using an exponential distribution to determine when the next event will occur. This function populates a vector of queues, whose beginning is obtained by the parameter beg. The vector of queues is structured as follows: at position beg + i, we have the queue of events whose source gid belongs to the i^th cellgroup.
+	\warning this implementation lacks a biological implementation, since no two events can happen at the same time. This would imply that, in the whole network, only one cell fired at a time .
     */
     template< typename Iterator >
     void generate_events_kai(Iterator beg, int simtime, int ngroups, int rank, int nprocs, int ncells, double lambda);
 
+    /** \fn void generate_poisson_events(Iterator beg, int simtime, int ngroups, int rank, int nprocs, int ncells, double lambda)
+        \brief generates events based on a poisson distribution approximation.
+	\param beg iterator to the beginning of the vector of queues of events.
+	\param simtime total time of simulation (in number of timesteps)
+	\param ngroups number of cellgroups per distributed rank
+	\param rank distributed rank number
+	\param nprocs the total number of distributed ranks in the whole simulation
+	\param ncells the total number of cells in the whole simulation
+	\param lambda the firing frequency of a single cell (in num events/timestep )
+
+	This implementation draws, at each timestep, a number of events from a Poisson distribution (see e.g. <a href="https://en.wikipedia.org/wiki/Poisson_distribution"> the Wikipedia page</a>). It distributes these events randomly among cells, without keeping memory of the history of each cell. There is no refractory period.
+*/
     template< typename Iterator >
     void generate_poisson_events(Iterator beg, int simtime, int ngroups, int rank, int nprocs, int ncells, double lambda);
 
+    /** \fn void generate_uniform_events(Iterator beg, int simtime, int ngroups, int rank, int nprocs, int ncells, double firing_interval)
+        \brief generates events based on a poisson distribution approximation.
+	\param beg iterator to the beginning of the vector of queues of events.
+	\param simtime total time of simulation (in number of timesteps)
+	\param ngroups number of cellgroups per distributed rank
+	\param rank distributed rank number
+	\param nprocs the total number of distributed ranks in the whole simulation
+	\param ncells the total number of cells in the whole simulation
+	\param firing_interval the interval between spikes (in timesteps)
+
+	In this implementation, _all_ the cells fire at every multiple of the firing interval.
+	\warning firing_interval must be strictly positive. In debug mode, this is asserted.
+*/
     template< typename Iterator >
-    void generate_uniform_events(Iterator beg, int simtime, int ngroups, int rank, int nprocs, int ncells, double firing_interval);
+    void generate_uniform_events(Iterator beg, int simtime, int ngroups, int rank, int nprocs, int ncells, int firing_interval);
 
 }
 

--- a/neuromapp/coreneuron_1.0/event_passing/environment/event_generators.ipp
+++ b/neuromapp/coreneuron_1.0/event_passing/environment/event_generators.ipp
@@ -1,0 +1,58 @@
+namespace environment {
+
+template< typename Iterator >
+void generate_events_kai(Iterator beg, Iterator end, int simtime, int ngroups, int rank, int nprocs, int ncells, double lambda) {
+
+    int dest = 0;
+    double event_time = 0;
+    int src_gid = 0;
+    gen_event new_event;
+
+    int cells_per = ncells / nprocs;
+    int start = rank * cells_per;
+
+    //for the last rank, add the remaining cellgroups
+    if(rank == (nprocs - 1))
+	cells_per = ncells - start;
+
+    //create random number generator/distributions
+    /*
+    * rng       => random number generator
+    * time_d    => exponential distribution of event times
+    * gid_d     => uniform distribution to create indices for output gids
+    * percent_d => uniform distribution to decide event type based on percent
+    */
+
+    boost::mt19937 rng(rank + time(NULL));
+    boost::random::exponential_distribution<double> time_d(lambda);
+    boost::random::uniform_int_distribution<> gid_d(start, (start + cells_per - 1));
+
+    event_time = 0;
+    Iterator it;
+    //create events up until simulation end
+    while(event_time < simtime){
+	double diff = time_d(rng);
+	assert(diff > 0.0);
+	event_time += diff;
+	if(event_time >= simtime){
+	    break;
+	} else {
+	    src_gid = gid_d(rng);
+
+	    //cellgroups are determined by:
+	    //group # = gid % number of groups
+	    dest = src_gid % ngroups;
+
+	    new_event.first = src_gid;
+	    new_event.second = static_cast<int>(event_time);
+
+	    it = beg;
+            std::advance(it, dest);
+	    it->push(new_event);
+	}
+    }
+}
+
+
+
+} // close namespace environment

--- a/neuromapp/coreneuron_1.0/event_passing/environment/event_generators.ipp
+++ b/neuromapp/coreneuron_1.0/event_passing/environment/event_generators.ipp
@@ -1,7 +1,7 @@
 namespace environment {
 
 template< typename Iterator >
-void generate_events_kai(Iterator beg, Iterator end, int simtime, int ngroups, int rank, int nprocs, int ncells, double lambda) {
+void generate_events_kai(Iterator beg, int simtime, int ngroups, int rank, int nprocs, int ncells, double lambda) {
 
     int dest = 0;
     double event_time = 0;
@@ -49,6 +49,101 @@ void generate_events_kai(Iterator beg, Iterator end, int simtime, int ngroups, i
 	    it = beg;
             std::advance(it, dest);
 	    it->push(new_event);
+	}
+    }
+}
+
+template< typename Iterator >
+void generate_poisson_events(Iterator beg, int simtime, int ngroups, int rank, int nprocs, int ncells, double lambda) {
+
+    int dest = 0;
+    double event_time = 0;
+    int src_gid = 0;
+    gen_event new_event;
+
+    int cells_per = ncells / nprocs;
+    int start = rank * cells_per;
+
+    //for the last rank, add the remaining cellgroups
+    if(rank == (nprocs - 1))
+	cells_per = ncells - start;
+
+    //create random number generator/distributions
+    /*
+    * rng       => random number generator
+    * time_d    => exponential distribution of event times
+    * gid_d     => uniform distribution to create indices for output gids
+    * percent_d => uniform distribution to decide event type based on percent
+    */
+
+    boost::mt19937 rng(rank + time(NULL));
+    boost::random::poisson_distribution<int> event_d(lambda);
+    boost::random::uniform_int_distribution<> gid_d(start, (start + cells_per - 1));
+
+    event_time = 0;
+    Iterator it;
+    int event_num;
+    //create events up until simulation end
+    for(event_time = 0; event_time < simtime; ++event_time){
+	event_num = event_d(rng);
+	if(event_num >= cells_per) event_num = cells_per; // ensures you don't have more events than c    ells, although this is not statistically correct...
+
+	for( int event_count = 0; event_count < event_num; ++event_count) {
+	    src_gid = gid_d(rng);
+
+	    //cellgroups are determined by:
+	    //group # = gid % number of groups
+	    dest = src_gid % ngroups;
+
+	    new_event.first = src_gid;
+	    new_event.second = static_cast<int>(event_time);
+
+	    it = beg;
+            std::advance(it, dest);
+	    it->push(new_event);
+	}
+    }
+}
+
+
+template< typename Iterator >
+void generate_uniform_events(Iterator beg, int simtime, int ngroups, int rank, int nprocs, int ncells, double firing_interval) {
+
+    int dest = 0;
+    double event_time = 0;
+    int src_gid = 0;
+    gen_event new_event;
+
+    int cells_per = ncells / nprocs;
+    int start = rank * cells_per;
+
+    //for the last rank, add the remaining cellgroups
+    if(rank == (nprocs - 1))
+	cells_per = ncells - start;
+
+    event_time = 0;
+    Iterator it;
+    int event_num;
+    //create events up until simulation end
+    while(event_time < simtime){
+	event_time += firing_interval;
+	if(event_time >= simtime){
+	    break;
+	} else {
+	    for(src_gid = start; src_gid < start + cells_per; ++src_gid) {
+
+	    //cellgroups are determined by:
+	    //group # = gid % number of groups
+	    dest = src_gid % ngroups;
+
+	    new_event.first = src_gid;
+	    new_event.second = static_cast<int>(event_time);
+
+	    it = beg;
+            std::advance(it, dest);
+	    it->push(new_event);
+
+	    }
 	}
     }
 }

--- a/neuromapp/coreneuron_1.0/event_passing/environment/event_generators.ipp
+++ b/neuromapp/coreneuron_1.0/event_passing/environment/event_generators.ipp
@@ -24,7 +24,7 @@ void generate_events_kai(Iterator beg, int simtime, int ngroups, int rank, int n
     */
 
     boost::mt19937 rng(rank + time(NULL));
-    boost::random::exponential_distribution<double> time_d(lambda);
+    boost::random::exponential_distribution<double> time_d(ncells*lambda/nprocs);
     boost::random::uniform_int_distribution<> gid_d(start, (start + cells_per - 1));
 
     event_time = 0;
@@ -77,7 +77,7 @@ void generate_poisson_events(Iterator beg, int simtime, int ngroups, int rank, i
     */
 
     boost::mt19937 rng(rank + time(NULL));
-    boost::random::poisson_distribution<int> event_d(lambda);
+    boost::random::poisson_distribution<int> event_d(ncells*lambda/nprocs);
     boost::random::uniform_int_distribution<> gid_d(start, (start + cells_per - 1));
 
     event_time = 0;
@@ -107,7 +107,9 @@ void generate_poisson_events(Iterator beg, int simtime, int ngroups, int rank, i
 
 
 template< typename Iterator >
-void generate_uniform_events(Iterator beg, int simtime, int ngroups, int rank, int nprocs, int ncells, double firing_interval) {
+void generate_uniform_events(Iterator beg, int simtime, int ngroups, int rank, int nprocs, int ncells, int firing_interval) {
+
+    assert(firing_interval > 0);
 
     int dest = 0;
     double event_time = 0;
@@ -123,7 +125,6 @@ void generate_uniform_events(Iterator beg, int simtime, int ngroups, int rank, i
 
     event_time = 0;
     Iterator it;
-    int event_num;
     //create events up until simulation end
     while(event_time < simtime){
 	event_time += firing_interval;
@@ -137,7 +138,7 @@ void generate_uniform_events(Iterator beg, int simtime, int ngroups, int rank, i
 	    dest = src_gid % ngroups;
 
 	    new_event.first = src_gid;
-	    new_event.second = static_cast<int>(event_time);
+	    new_event.second = event_time;
 
 	    it = beg;
             std::advance(it, dest);

--- a/neuromapp/coreneuron_1.0/event_passing/environment/generator.cpp
+++ b/neuromapp/coreneuron_1.0/event_passing/environment/generator.cpp
@@ -14,61 +14,8 @@
 
 namespace environment {
 
-event_generator::event_generator(int nSpikes, int simtime,
-int ngroups, int rank, int nprocs, int ncells){
-    int dest = 0;
-    double event_time = 0;
-    int src_gid = 0;
-    double percent = 0;
-    gen_event new_event;
-    presyn* output;
-
-    assert(nSpikes > 0);
-    int cells_per = ncells / nprocs;
-    int start = rank * cells_per;
-
-    //for the last rank, add the remaining cellgroups
-    if(rank == (nprocs - 1))
-        cells_per = ncells - start;
-
-    double mean = static_cast<double>(simtime) / static_cast<double>(nSpikes);
-    double lambda = 1.0 / static_cast<double>(mean * nprocs);
-
-    //create random number generator/distributions
-    /*
-     * rng       => random number generator
-     * time_d    => exponential distribution of event times
-     * gid_d     => uniform distribution to create indices for output gids
-     * percent_d => uniform distribution to decide event type based on percent
-     */
-    boost::mt19937 rng(rank + time(NULL));
-    boost::random::exponential_distribution<double> time_d(lambda);
-    boost::random::uniform_int_distribution<> gid_d(start, (start + cells_per - 1));
-    boost::random::uniform_int_distribution<> cellgroup_d(0, (ngroups-1));
-
-
+event_generator::event_generator(int ngroups){
     event_pool_.resize(ngroups);
-    event_time = 0;
-    //create events up until simulation end
-    while(event_time < simtime){
-        double diff = time_d(rng);
-        assert(diff > 0.0);
-        event_time += diff;
-        if(event_time >= simtime){
-            break;
-        }
-        else{
-            src_gid = gid_d(rng);
-
-            //cellgroups are determined by:
-            //group # = gid % number of groups
-            dest = src_gid % ngroups;
-
-            new_event.first = src_gid;
-            new_event.second = static_cast<int>(event_time);
-            event_pool_[dest].push(new_event);
-        }
-    }
 }
 
 bool event_generator::compare_top_lte(int id, double comparator) const{

--- a/neuromapp/coreneuron_1.0/event_passing/environment/generator.h
+++ b/neuromapp/coreneuron_1.0/event_passing/environment/generator.h
@@ -8,6 +8,7 @@
 #include "coreneuron_1.0/event_passing/environment/presyn_maker.h"
 #include "coreneuron_1.0/event_passing/queueing/queue.h"
 
+//! namespace for handling spike event generation and distributions of cells/presyns across multiple ranks
 namespace environment {
 
 //create a pair out of time and presyn

--- a/neuromapp/coreneuron_1.0/event_passing/environment/generator.h
+++ b/neuromapp/coreneuron_1.0/event_passing/environment/generator.h
@@ -24,6 +24,16 @@ private:
 
 public:
 
+    typedef std::vector<std::queue<gen_event> >::iterator iterator;
+    typedef std::vector<std::queue<gen_event> >::const_iterator const_iterator;
+
+    iterator begin() {return event_pool_.begin();};
+    const_iterator begin() const {return event_pool_.begin();};
+
+    iterator end() {return event_pool_.end();};
+    const_iterator end() const {return event_pool_.end();};
+
+
     /** \fn event_generator(int nSpike, int simtime, int ngroups,
      *      int rank, int nprocs, int ncells)
      *  \brief the generator constructor. Creates all the events.
@@ -34,8 +44,7 @@ public:
      *  \param nprocs the number of processes in the simulation
      *  \param ncells the total number of cells
      */
-    event_generator(int nSpikes, int simtime, int ngroups,
-    int rank, int nprocs, int ncells);
+    event_generator(int ngroups);
 
     /** \fn gen_event pop()(int id)
      *  \brief retrieves the top most element from the specified queue

--- a/test/coreneuron_1.0/event_passing/environment.cpp
+++ b/test/coreneuron_1.0/event_passing/environment.cpp
@@ -150,7 +150,7 @@ BOOST_AUTO_TEST_CASE(generator_kai){
     environment::event_generator generator(ngroups);
 
     double mean = static_cast<double>(simtime) / static_cast<double>(nspike);
-    double lambda = 1.0 / static_cast<double>(mean * nprocs);
+    double lambda = 1.0 / static_cast<double>(mean * ncells);
 
     environment::generate_events_kai(generator.begin(),
                             simtime, ngroups, rank, nprocs, ncells, lambda);
@@ -199,7 +199,7 @@ BOOST_AUTO_TEST_CASE(generator_poisson){
     environment::event_generator generator(ngroups);
 
     double mean = static_cast<double>(simtime) / static_cast<double>(nspike);
-    double lambda = 1.0 / static_cast<double>(mean * nprocs);
+    double lambda = 1.0 / static_cast<double>(mean * ncells);
 
     environment::generate_poisson_events(generator.begin(),
                             simtime, ngroups, rank, nprocs, ncells, lambda);
@@ -248,7 +248,7 @@ BOOST_AUTO_TEST_CASE(generator_uniform){
     environment::event_generator generator(ngroups);
 
     double firing_freq = static_cast<double>(nspike) / static_cast<double>(simtime*ncells);
-    double firing_interval = 1.0 / firing_freq;
+    int firing_interval = static_cast<int>(1.0 / firing_freq);
 
     environment::generate_poisson_events(generator.begin(),
                             simtime, ngroups, rank, nprocs, ncells, firing_interval);

--- a/test/coreneuron_1.0/event_passing/environment.cpp
+++ b/test/coreneuron_1.0/event_passing/environment.cpp
@@ -32,6 +32,7 @@
 #include <ctime>
 
 #include "coreneuron_1.0/event_passing/environment/generator.h"
+#include "coreneuron_1.0/event_passing/environment/event_generators.hpp"
 #include "coreneuron_1.0/event_passing/environment/presyn_maker.h"
 
 /**
@@ -145,8 +146,14 @@ BOOST_AUTO_TEST_CASE(generator_constructor){
     //generate events
     environment::presyn_maker p(ncells, fanin);
     p(nprocs, ngroups, rank);
-    environment::event_generator generator(nspike, simtime, ngroups,
-    rank, nprocs, ncells);
+
+    environment::event_generator generator(ngroups);
+
+    double mean = static_cast<double>(simtime) / static_cast<double>(nspike);
+    double lambda = 1.0 / static_cast<double>(mean * nprocs);
+
+    environment::generate_events_kai(generator.begin(), generator.end(),
+                            simtime, ngroups, rank, nprocs, ncells, lambda);
 
     environment::gen_event ev;
     BOOST_CHECK(!generator.empty(0));
@@ -186,8 +193,13 @@ BOOST_AUTO_TEST_CASE(generator_compare_top_lte){
     int rank = 0;
 
     //generate events
-    environment::event_generator generator(nspike, simtime,
-    ngroups, rank, nprocs, ncells);
+    environment::event_generator generator(ngroups);
+
+    double mean = static_cast<double>(simtime) / static_cast<double>(nspike);
+    double lambda = 1.0 / static_cast<double>(mean * nprocs);
+
+    environment::generate_events_kai(generator.begin(), generator.end(),
+                             simtime, ngroups, rank, nprocs, ncells, lambda);
 
     bool greater_than_min = true;
     bool less_than_max = true;

--- a/test/coreneuron_1.0/event_passing/environment.cpp
+++ b/test/coreneuron_1.0/event_passing/environment.cpp
@@ -130,9 +130,9 @@ BOOST_AUTO_TEST_CASE(presyns_find_test){
 }
 
 /**
- * Test constructor of event_generator class
+ * Test generation of events for kai_generator
  */
-BOOST_AUTO_TEST_CASE(generator_constructor){
+BOOST_AUTO_TEST_CASE(generator_kai){
     boost::mt19937 rng(time(NULL));
     boost::random::uniform_int_distribution<> uniform(50, 100);
     int nspike = uniform(rng);
@@ -152,7 +152,7 @@ BOOST_AUTO_TEST_CASE(generator_constructor){
     double mean = static_cast<double>(simtime) / static_cast<double>(nspike);
     double lambda = 1.0 / static_cast<double>(mean * nprocs);
 
-    environment::generate_events_kai(generator.begin(), generator.end(),
+    environment::generate_events_kai(generator.begin(),
                             simtime, ngroups, rank, nprocs, ncells, lambda);
 
     environment::gen_event ev;
@@ -181,6 +181,105 @@ BOOST_AUTO_TEST_CASE(generator_constructor){
     BOOST_CHECK(valid_gid);
 }
 
+BOOST_AUTO_TEST_CASE(generator_poisson){
+    boost::mt19937 rng(time(NULL));
+    boost::random::uniform_int_distribution<> uniform(50, 100);
+    int nspike = uniform(rng);
+    int ncells = 10;
+    int nprocs = 1;
+    int ngroups = 1;
+    int simtime = 100;
+    int rank = 0;
+    int fanin = ncells;
+
+    //generate events
+    environment::presyn_maker p(ncells, fanin);
+    p(nprocs, ngroups, rank);
+
+    environment::event_generator generator(ngroups);
+
+    double mean = static_cast<double>(simtime) / static_cast<double>(nspike);
+    double lambda = 1.0 / static_cast<double>(mean * nprocs);
+
+    environment::generate_poisson_events(generator.begin(),
+                            simtime, ngroups, rank, nprocs, ncells, lambda);
+
+    environment::gen_event ev;
+    BOOST_CHECK(!generator.empty(0));
+
+    //check that all generated events have valid time and presyns
+    bool valid_time = true;
+    bool valid_gid = true;
+    int gid = 0;
+    while(!generator.empty(0)){
+        ev = generator.pop(0);
+        //time
+        if(ev.second > simtime || ev.second < 0){
+            valid_time = false;
+            std::cerr<<"Error: invalid time: "<<ev.second<<std::endl;
+            break;
+        }
+        gid = ev.first;
+        if(!p.find_output(gid)){
+            std::cerr<<"Error: gid not found: "<<gid<<std::endl;
+            valid_gid = false;
+            break;
+        }
+    }
+    BOOST_CHECK(valid_time);
+    BOOST_CHECK(valid_gid);
+}
+
+BOOST_AUTO_TEST_CASE(generator_uniform){
+    boost::mt19937 rng(time(NULL));
+    boost::random::uniform_int_distribution<> uniform(50, 100);
+    int nspike = uniform(rng);
+    int ncells = 10;
+    int nprocs = 1;
+    int ngroups = 1;
+    int simtime = 100;
+    int rank = 0;
+    int fanin = ncells;
+
+    //generate events
+    environment::presyn_maker p(ncells, fanin);
+    p(nprocs, ngroups, rank);
+
+    environment::event_generator generator(ngroups);
+
+    double firing_freq = static_cast<double>(nspike) / static_cast<double>(simtime*ncells);
+    double firing_interval = 1.0 / firing_freq;
+
+    environment::generate_poisson_events(generator.begin(),
+                            simtime, ngroups, rank, nprocs, ncells, firing_interval);
+
+    environment::gen_event ev;
+    BOOST_CHECK(!generator.empty(0));
+
+    //check that all generated events have valid time and presyns
+    bool valid_time = true;
+    bool valid_gid = true;
+    int gid = 0;
+    while(!generator.empty(0)){
+        ev = generator.pop(0);
+        //time
+        if(ev.second > simtime || ev.second < 0){
+            valid_time = false;
+            std::cerr<<"Error: invalid time: "<<ev.second<<std::endl;
+            break;
+        }
+        gid = ev.first;
+        if(!p.find_output(gid)){
+            std::cerr<<"Error: gid not found: "<<gid<<std::endl;
+            valid_gid = false;
+            break;
+        }
+    }
+    BOOST_CHECK(valid_time);
+    BOOST_CHECK(valid_gid);
+}
+
+
 /**
  * Test the compare less than/equals function of event_generator class
  */
@@ -198,7 +297,7 @@ BOOST_AUTO_TEST_CASE(generator_compare_top_lte){
     double mean = static_cast<double>(simtime) / static_cast<double>(nspike);
     double lambda = 1.0 / static_cast<double>(mean * nprocs);
 
-    environment::generate_events_kai(generator.begin(), generator.end(),
+    environment::generate_events_kai(generator.begin(),
                              simtime, ngroups, rank, nprocs, ncells, lambda);
 
     bool greater_than_min = true;

--- a/test/coreneuron_1.0/event_passing/queueing.cpp
+++ b/test/coreneuron_1.0/event_passing/queueing.cpp
@@ -225,7 +225,7 @@ BOOST_AUTO_TEST_CASE(pool_constructor){
     double mean = static_cast<double>(simtime) / static_cast<double>(nspikes);
     double lambda = 1.0 / static_cast<double>(mean * nprocs);
 
-    environment::generate_events_kai(generator.begin(), generator.end(),
+    environment::generate_events_kai(generator.begin(),
                     simtime, ngroups, rank, nprocs, ncells, lambda);
 
 }
@@ -259,7 +259,7 @@ BOOST_AUTO_TEST_CASE(pool_fixed_step_1mindelay){
     double mean = static_cast<double>(simtime) / static_cast<double>(nspikes);
     double lambda = 1.0 / static_cast<double>(mean * nprocs);
 
-    environment::generate_events_kai(generator.begin(), generator.end(),
+    environment::generate_events_kai(generator.begin(),
                     simtime, ngroups, rank, nprocs, ncells, lambda);
 
     int sum_events = 0;
@@ -300,7 +300,7 @@ BOOST_AUTO_TEST_CASE(pool_send_ite){
     double mean = static_cast<double>(simtime) / static_cast<double>(nspikes);
     double lambda = 1.0 / static_cast<double>(mean * nprocs);
 
-    environment::generate_events_kai(generator.begin(), generator.end(),
+    environment::generate_events_kai(generator.begin(),
                     simtime, ngroups, rank, nprocs, ncells, lambda);
 
     int sum_events = 0;

--- a/test/coreneuron_1.0/event_passing/queueing.cpp
+++ b/test/coreneuron_1.0/event_passing/queueing.cpp
@@ -37,6 +37,7 @@
 #include "coreneuron_1.0/event_passing/queueing/pool.h"
 #include "coreneuron_1.0/event_passing/queueing/thread.h"
 #include "coreneuron_1.0/event_passing/environment/generator.h"
+#include "coreneuron_1.0/event_passing/environment/event_generators.hpp"
 #include "coreneuron_1.0/event_passing/environment/presyn_maker.h"
 #include "coreneuron_1.0/event_passing/spike/spike_interface.h"
 #include "utils/error.h"
@@ -210,18 +211,24 @@ BOOST_AUTO_TEST_CASE(pool_constructor){
   * in commit 86f12a902962d16a227009ff1a0bb8ebe42a2e3
   */
  BOOST_AUTO_TEST_CASE(generator_constructor){
-     int ncells = 4;
-     int fanin = 4;
-     int ngroups = 1;
-     int nspikes = 100;
-     int rank = 1;
-     int nprocs = 2;
+    int ncells = 4;
+    int fanin = 4;
+    int ngroups = 1;
+    int nspikes = 100;
+    int rank = 1;
+    int nprocs = 2;
 
-     int simtime = 1;
+    int simtime = 1;
 
-     environment::event_generator generator(nspikes, simtime, ngroups,
-     rank, nprocs, ncells);
- }
+    environment::event_generator generator(ngroups);
+
+    double mean = static_cast<double>(simtime) / static_cast<double>(nspikes);
+    double lambda = 1.0 / static_cast<double>(mean * nprocs);
+
+    environment::generate_events_kai(generator.begin(), generator.end(),
+                    simtime, ngroups, rank, nprocs, ncells, lambda);
+
+}
 
 
 
@@ -247,8 +254,14 @@ BOOST_AUTO_TEST_CASE(pool_fixed_step_1mindelay){
 
     //generate
     presyns(nprocs, ngroups, rank);
-    environment::event_generator generator(nspikes, simtime, ngroups,
-    rank, nprocs, ncells);
+    environment::event_generator generator(ngroups);
+
+    double mean = static_cast<double>(simtime) / static_cast<double>(nspikes);
+    double lambda = 1.0 / static_cast<double>(mean * nprocs);
+
+    environment::generate_events_kai(generator.begin(), generator.end(),
+                    simtime, ngroups, rank, nprocs, ncells, lambda);
+
     int sum_events = 0;
     for(int i = 0; i < ngroups; ++i){
         sum_events += generator.get_size(i);
@@ -282,8 +295,13 @@ BOOST_AUTO_TEST_CASE(pool_send_ite){
 
     //generate
     presyns(nprocs, ngroups, rank);
-    environment::event_generator generator(nspikes, simtime,
-    ngroups, rank, nprocs, ncells);
+    environment::event_generator generator(ngroups);
+
+    double mean = static_cast<double>(simtime) / static_cast<double>(nspikes);
+    double lambda = 1.0 / static_cast<double>(mean * nprocs);
+
+    environment::generate_events_kai(generator.begin(), generator.end(),
+                    simtime, ngroups, rank, nprocs, ncells, lambda);
 
     int sum_events = 0;
     for(int i = 0; i < ngroups; ++i){

--- a/test/coreneuron_1.0/event_passing/spike.cpp
+++ b/test/coreneuron_1.0/event_passing/spike.cpp
@@ -31,6 +31,7 @@
 #include <time.h>
 #include <stdlib.h>
 #include <numeric>
+#include <iostream>
 
 #include "coreneuron_1.0/common/data/helper.h"
 #include "coreneuron_1.0/event_passing/spike/algos.hpp"
@@ -41,16 +42,18 @@ namespace bfs = ::boost::filesystem;
 //Performs MPI init/finalize
 #include "test/tools/mpi_helper.h"
 
+
+
 /**
  * tests the create_spike_type() function.
  * checks that this data type can be freed using
  * MPI_Type_free
  */
 BOOST_AUTO_TEST_CASE(create_spike_type_test){
+    std::cerr << "create_spike_type_test" << std::endl;
     MPI_Datatype spike = create_spike_type();
     MPI_Type_free(&spike);
 }
-
 
 /**
  * test that the set displ function works
@@ -68,13 +71,16 @@ BOOST_AUTO_TEST_CASE(displ_test){
     MPI_Comm_size(MPI_COMM_WORLD, &size);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 
-    spike::spike_interface interface(size);
 
+    std::cerr << "displ_test" << std::endl;
+    spike::spike_interface interface(size);
     for(int i = 0; i < size; ++i){
         interface.nin_[i] = rand()%5;
     }
 
+    std::cerr << "displ_test2" << std::endl;
     set_displ(interface);
+    std::cerr << "displ_test3" << std::endl;
     int sum = 0;
     for(int i = 0; i < size; ++i){
         BOOST_CHECK(interface.displ_[i] == sum);


### PR DESCRIPTION
# Yolo generation of events!

Dem sweet events being generated according to different policies, to accomodate for everyone's taste and likings. 

**Beware** the API of `environment::event_generator` function has changed!!
Now the generation of events is handled by free functions in the environment namespace, which access the `event_generator`'s privates through a convenient iterator `begin()` interface. 
Long live the STL style!