### PR TITLE
remove useless template specialisation 

### DIFF
--- a/neuromapp/coreneuron_1.0/event_passing/queueing/queue.cpp
+++ b/neuromapp/coreneuron_1.0/event_passing/queueing/queue.cpp
@@ -34,9 +34,7 @@
 namespace queueing {
 
 void queue::insert(double tt, int d) {
-    event e;
-    e.data_ = d;
-    e.t_ = tt;
+    event e(tt,d);
     pq_que.push(e);
 }
 

--- a/neuromapp/coreneuron_1.0/event_passing/queueing/queue.cpp
+++ b/neuromapp/coreneuron_1.0/event_passing/queueing/queue.cpp
@@ -34,7 +34,7 @@
 namespace queueing {
 
 void queue::insert(double tt, int d) {
-    event e(tt,d);
+    event e(d,tt);
     pq_que.push(e);
 }
 

--- a/neuromapp/coreneuron_1.0/event_passing/queueing/queue.h
+++ b/neuromapp/coreneuron_1.0/event_passing/queueing/queue.h
@@ -29,6 +29,8 @@
 #include <vector>
 #include <map>
 #include <utility>
+#include <functional>
+
 
 #ifndef MAPP_CONTAINER_H_
 #define MAPP_CONTAINER_H_
@@ -38,20 +40,17 @@ namespace queueing {
 struct event {
     int data_;
     double t_;
+    //        /** \fn operator <
+    //         *  \brief compares the time of two events
+    //         *  \return true if *this(time) < x(time), else false
+    //         */
+    inline bool operator>(const event &x) const {
+        return t_ > x.t_;
+    }
 };
 
 class queue {
 public:
-    struct is_more{
-        /** \fn operator()
-         *  \brief compares the time of two events
-         *  \return true if x(time) < y(time), else false
-         */
-        bool operator() (const event &x, const event &y) const {
-                return x.t_ > y.t_;
-        }
-    };
-
     /** \fn size()
      *  \return the size of pq_que
      */
@@ -73,7 +72,7 @@ public:
     void insert(double t, int data);
 
 private:
-    std::priority_queue<event, is_more> pq_que;
+    std::priority_queue<event, std::vector<event>, std::greater<event> > pq_que;
 };
 
 } //end of namespace

--- a/neuromapp/coreneuron_1.0/event_passing/queueing/queue.h
+++ b/neuromapp/coreneuron_1.0/event_passing/queueing/queue.h
@@ -38,6 +38,7 @@
 namespace queueing {
 
 struct event {
+    explicit event(int d = 0, double t = 0.):data_(d),t_(t){};
     int data_;
     double t_;
     //        /** \fn operator <

--- a/neuromapp/coreneuron_1.0/event_passing/queueing/queue.h
+++ b/neuromapp/coreneuron_1.0/event_passing/queueing/queue.h
@@ -73,7 +73,7 @@ public:
     void insert(double t, int data);
 
 private:
-    std::priority_queue<event, std::vector<event>, is_more> pq_que;
+    std::priority_queue<event, is_more> pq_que;
 };
 
 } //end of namespace


### PR DESCRIPTION
From the standard:

template<
    class T,
    class Container = std::vector<T>,
    class Compare = std::less<typename Container::value_type>
> class priority_queue;