### PR TITLE
Improved compatibility with OpenMP.

### DIFF
--- a/neuromapp/coreneuron_1.0/event_passing/drivers/distributed_driver.cpp
+++ b/neuromapp/coreneuron_1.0/event_passing/drivers/distributed_driver.cpp
@@ -40,9 +40,8 @@
 #include "coreneuron_1.0/event_passing/spike/distributed.hpp"
 #include "utils/storage/neuromapp_data.h"
 
-#ifdef _OPENMP
-    #include <omp.h>
-#endif
+// Get OMP header if available
+#include "utils/omp/compatibility.h"
 
 
 int main(int argc, char* argv[]) {

--- a/neuromapp/coreneuron_1.0/event_passing/drivers/event.cpp
+++ b/neuromapp/coreneuron_1.0/event_passing/drivers/event.cpp
@@ -40,9 +40,8 @@
 #include "coreneuron_1.0/event_passing/drivers/drivers.h"
 #include "utils/storage/neuromapp_data.h"
 
-#ifdef _OPENMP
-    #include <omp.h>
-#endif
+// Get OMP header if available
+#include "utils/omp/compatibility.h"
 
 int main(int argc, char* argv[]) {
 

--- a/neuromapp/coreneuron_1.0/event_passing/queueing/pool.h
+++ b/neuromapp/coreneuron_1.0/event_passing/queueing/pool.h
@@ -32,9 +32,8 @@
 #include "coreneuron_1.0/event_passing/spike/spike_interface.h"
 #include "utils/storage/neuromapp_data.h"
 
-#ifdef _OPENMP
-#include <omp.h>
-#endif
+// Get OMP header if available
+#include "utils/omp/compatibility.h"
 
 namespace queueing {
 

--- a/neuromapp/coreneuron_1.0/event_passing/queueing/thread.h
+++ b/neuromapp/coreneuron_1.0/event_passing/queueing/thread.h
@@ -36,12 +36,11 @@
 #include "utils/storage/storage.h"
 
 #include "coreneuron_1.0/event_passing/queueing/queue.h"
-#include "utils/omp/lock.h"
 #include "coreneuron_1.0/common/data/helper.h"
 
-#ifdef _OPENMP
-#include <omp.h>
-#endif
+// Get OMP header if available
+#include "utils/omp/compatibility.h"
+#include "utils/omp/lock.h"
 
 namespace queueing {
 

--- a/neuromapp/coreneuron_1.0/kernel/main.c
+++ b/neuromapp/coreneuron_1.0/kernel/main.c
@@ -39,9 +39,8 @@
 #include "coreneuron_1.0/common/util/timer.h"
 #include "utils/error.h"
 
-#ifdef _OPENMP
-#include <omp.h>
-#endif
+// Get OMP header if available
+#include "utils/omp/compatibility.h"
 
 /** \fn compute_wrapper(NrnThread *nt, struct input_parameters* p)
     \brief Start the computation of kernel following the input parameter
@@ -59,9 +58,7 @@ int coreneuron10_kernel_execute(int argc, char *const argv[])
     if(error != MAPP_OK)
         return error;
 
-#ifdef _OPENMP
     omp_set_num_threads(p.th);
-#endif
 
     NrnThread * nt = (NrnThread *) storage_get (p.name,  make_nrnthread, p.d, free_nrnthread);
     if(nt == NULL){

--- a/neuromapp/hello/main.cpp
+++ b/neuromapp/hello/main.cpp
@@ -26,9 +26,8 @@
 #include <iostream>
 #include <string>
 
-#ifdef _OPENMP
-#include <omp.h>
-#endif
+// Get OMP header if available
+#include "utils/omp/compatibility.h"
 
 #include <boost/program_options.hpp>
 
@@ -55,9 +54,7 @@ int help(int argc, char* const argv[], po::variables_map& vm){
     po::store(po::parse_command_line(argc, argv, desc), vm);
     po::notify(vm);
 
-#ifdef _OPENMP
     omp_set_num_threads(vm["numthread"].as<int>());
-#endif
 
     if (vm.count("help")){
         std::cout << desc;
@@ -74,13 +71,9 @@ void content(po::variables_map const& vm){
     #pragma omp parallel
     #pragma omp critical
     {
-#ifdef _OPENMP
         std::cout << "Hello " << vm["name"].as<std::string>()
                   << ", total thread: " << vm["numthread"].as<int>()
                   << ", thread id: " << omp_get_thread_num() << "\n";
-#else
-        std::cout << "Hello " << vm["name"].as<std::string>() << "\n";
-#endif
     }
 }
 

--- a/neuromapp/iobench/backends/map.h
+++ b/neuromapp/iobench/backends/map.h
@@ -27,14 +27,12 @@
 #ifndef MAPP_IOBENCH_MAP_
 #define MAPP_IOBENCH_MAP_
 
-#ifdef _OPENMP
-#include <omp.h>
-#endif
-
 #include <map>
 #include <vector>
 #include <cstring>
 
+// Get OMP header if available
+#include "utils/omp/compatibility.h"
 #include "utils/omp/lock.h"
 #include "iobench/backends/basic.h"
 
@@ -95,11 +93,7 @@ void MapKV::initDB(bool compress, int nthr, int npairs, int mpi_rank, int mpi_si
  */
 inline void MapKV::putKV(KVStatus * kvs, void * key, size_t key_size, void * value, size_t value_size)
 {
-    #ifdef _OPENMP
     int id = omp_get_thread_num();
-    #else
-    int id = 1;
-    #endif
 
     std::string kdata((char *) key, key_size);
     key_type k(kdata, key_size);
@@ -141,11 +135,7 @@ inline size_t MapKV::getKV (KVStatus * kvs, void * key, size_t key_size, void * 
  */
 inline void MapKV::waitKVput(std::vector<KVStatus *> &status, int start, int end)
 {
-#ifdef _OPENMP
     int id = omp_get_thread_num();
-#else
-    int id = 1;
-#endif
     _mapLock.lock();
     _map.insert(_thrMaps[id]->begin(), _thrMaps[id]->end());
     _mapLock.unlock();

--- a/neuromapp/iobench/benchmark.cpp
+++ b/neuromapp/iobench/benchmark.cpp
@@ -31,6 +31,9 @@
 #include "iobench/benchmark.h"
 #include "iobench/backends/common.h"
 
+// Get OMP header if available
+#include "utils/omp/compatibility.h"
+
 #ifdef IO_MPI
 #include <mpi.h>
 #include "utils/mpi/print.h"
@@ -115,11 +118,7 @@ void iobench::benchmark::createData() {
 
 #pragma omp parallel default(shared) //shared(keys_, values_, reads_) not allowed since they are class members
     {
-#ifdef _OPENMP
         int id = omp_get_thread_num();
-#else
-        int id = 0;
-#endif
         int start_idx = id * a_.npairs();
         for (int i = 0; i < a_.npairs(); i++) {
             // Set keys
@@ -216,11 +215,7 @@ void iobench::benchmark::write(stats & stats) {
         gettimeofday(&wr_start, NULL);
         #pragma omp parallel default(shared) //shared(keys_, values_, wr_perm, status) not allowed since there are class members
         {
-#ifdef _OPENMP
             int id = omp_get_thread_num();
-#else
-            int id = 0;
-#endif
             /////////////////////////////////////////////
             int start_idx = id * a_.npairs();
             for (int i = 0; i < a_.npairs(); i++) {
@@ -301,11 +296,7 @@ void iobench::benchmark::read(stats & stats) {
         gettimeofday(&rd_start, NULL);
 #pragma omp parallel default(shared) //shared(keys_, reads_, rd_perm, status) not allowed since there are class members
         {
-#ifdef _OPENMP
             int id = omp_get_thread_num();
-#else
-            int id = 0;
-#endif
             /////////////////////////////////////////////
             int start_idx = id * a_.npairs();
             for (int i = 0; i < a_.npairs(); i++) {

--- a/neuromapp/iobench/benchmark.h
+++ b/neuromapp/iobench/benchmark.h
@@ -27,13 +27,12 @@
 #ifndef MAPP_IOBENCH_BENCHMARK_
 #define MAPP_IOBENCH_BENCHMARK_
 
-#ifdef _OPENMP
-#include <omp.h>
-#endif
+// Get OMP header if available
+#include "utils/omp/compatibility.h"
+
 #include <map>
 
 #include "iobench/backends/basic.h"
-
 #include "iobench/utils/args.h"
 #include "iobench/utils/stats.h"
 

--- a/neuromapp/iobench/utils/args.h
+++ b/neuromapp/iobench/utils/args.h
@@ -34,9 +34,9 @@
 #include <cstdlib>
 #include <algorithm>
 #include <iostream>
-#ifdef _OPENMP
-   #include <omp.h>
-#endif
+
+// Get OMP header if available
+#include "utils/omp/compatibility.h"
 
 #ifdef IO_MPI
 #include "utils/mpi/controler.h"
@@ -102,11 +102,7 @@ public:
         // Get the number of threads from OpenMP
         #pragma omp parallel
         {
-#ifdef _OPENMP
             threads_ = omp_get_num_threads();
-#else
-            threads_ = 1;
-#endif
         }
     }
 

--- a/neuromapp/keyvalue/utils/argument.h
+++ b/neuromapp/keyvalue/utils/argument.h
@@ -34,11 +34,8 @@
 #include <cstdlib>
 #include <algorithm>
 #include <iostream>
-#ifdef _OPENMP
-   #include <omp.h>
-#else
-   #define omp_get_num_threads() 1
-#endif
+// Get OMP header if available
+#include "utils/omp/compatibility.h"
 
 #include "utils/mpi/controler.h"
 

--- a/neuromapp/nest/distributed_driver.cpp
+++ b/neuromapp/nest/distributed_driver.cpp
@@ -31,9 +31,8 @@
 #include <vector>
 #include "utils/storage/neuromapp_data.h"
 
-#ifdef _OPENMP
-    #include <omp.h>
-#endif
+// Get OMP header if available
+#include "utils/omp/compatibility.h"
 
 #include "nest/synapse/connectionmanager.h"
 #include "nest/simulationmanager.h"
@@ -108,18 +107,11 @@ int main(int argc, char* argv[]) {
     presyns(rank, &neuro_dist);
     nest::connectionmanager cn(vm);
 
-    #ifdef _OPENMP
     omp_set_num_threads(nthreads);
-    #endif
     #pragma omp parallel
     {
-        #ifdef _OPENMP
         const int thrd = omp_get_thread_num();
         const int num_threads = omp_get_num_threads();
-        #else
-        const int thrd = 0;
-        const int num_threads = 1;
-        #endif
 
         //neuron distribution on thread based on rank distribution
         environment::continousdistribution neuron_vp_dist(num_threads, thrd, &neuro_dist);
@@ -146,11 +138,7 @@ int main(int argc, char* argv[]) {
 
     #pragma omp parallel
     {
-        #ifdef _OPENMP
         const int thrd = omp_get_thread_num();
-        #else
-        const int thrd = 0;
-        #endif
 
         while(t < Tstop){
             #pragma omp barrier
@@ -176,13 +164,10 @@ int main(int argc, char* argv[]) {
         }
     }
 
-
-
     gettimeofday(&end, NULL);
 
     long long diff_ms = (1000 * (end.tv_sec - start.tv_sec))
         + ((end.tv_usec - start.tv_usec) / 1000);
-
 
     int l_num = 0;
     double  l_sumtime = 0;

--- a/neuromapp/nest/mpi_manager.h
+++ b/neuromapp/nest/mpi_manager.h
@@ -13,9 +13,8 @@
 #include <vector>
 
 #include <mpi.h>
-#ifdef _OPENMP
-    #include <omp.h>
-#endif
+// Get OMP header if available
+#include "utils/omp/compatibility.h"
 
 typedef unsigned int uint_t;
 

--- a/neuromapp/nest/synapse/connectionmanager.cpp
+++ b/neuromapp/nest/synapse/connectionmanager.cpp
@@ -7,10 +7,8 @@
 
 #include "nest/synapse/connectionmanager.h"
 
-
-#ifdef _OPENMP
-    #include <omp.h>
-#endif
+// Get OMP header if available
+#include "utils/omp/compatibility.h"
 
 namespace nest {
     connectionmanager::connectionmanager(po::variables_map const& vm):

--- a/neuromapp/nest/synapse/memory.h
+++ b/neuromapp/nest/synapse/memory.h
@@ -28,9 +28,8 @@
 #define MEMORY_H_
 
 #include <algorithm>
-#ifdef _OPENMP
-#include <omp.h>
-#endif
+// Get OMP header if available
+#include "utils/omp/compatibility.h"
 
 namespace nest{
 
@@ -224,11 +223,7 @@ namespace nest{
     inline Tnew*
     suicide_and_resurrect( Told* connector, C connection )
     {
-        #ifdef _OPENMP
         const int thrd = omp_get_thread_num();
-        #else
-        const int thrd = 1;
-        #endif
 
         Tnew* p = NULL;
        #pragma omp critical // not thread safe!!
@@ -247,11 +242,7 @@ namespace nest{
     inline T*
     allocate( C c )
     {
-        #ifdef _OPENMP
         const int thrd = omp_get_thread_num();
-        #else
-        const int thrd = 1;
-        #endif
 
         T* p = NULL;
        #pragma omp critical // not thread safe!!
@@ -265,11 +256,7 @@ namespace nest{
     inline T*
     allocate()
     {
-        #ifdef _OPENMP
         const int thrd = omp_get_thread_num();
-        #else
-        const int thrd = 0;
-        #endif
 
         T* p = NULL;
 #pragma omp critical // not thread safe!!

--- a/neuromapp/utils/omp/compatibility.h
+++ b/neuromapp/utils/omp/compatibility.h
@@ -1,0 +1,46 @@
+/*
+ * Neuromapp - compatibility.h, Copyright (c), 2015,
+ * Judit Planas - Swiss Federal Institute of technology in Lausanne,
+ * judit.planas@epfl.ch,
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+
+/**
+ * @file neuromapp/utils/omp/compatibility.h
+ * \brief Contains support for OMP functions when OMP is not available.
+ */
+
+#ifndef MAPP_COMP_H_
+#define MAPP_COMP_H_
+
+#ifdef _OPENMP
+// If OpenMP is available, include the header
+#include <omp.h>
+#else
+// Otherwise, define dummy functions so that the mini-apps work properly
+#include <iostream>
+
+inline int omp_get_num_threads() { return 1; }
+inline int omp_get_thread_num() { return 0; }
+void omp_set_num_threads (int threads)
+{
+    if (threads > 1)
+        std::cout << "Setting the number of OMP threads, but OMP is not available. Execution may be wrong!" << std::endl;
+}
+
+#endif
+
+#endif // MAPP_COMP_H_

--- a/neuromapp/utils/omp/lock.h
+++ b/neuromapp/utils/omp/lock.h
@@ -57,10 +57,12 @@ public:
 	inline void unlock(){omp_unset_lock(&mut_);}
 };
 
-    typedef omp_mutex mutex ;
+    typedef omp_mutex mutex;
 }
 
 #else
+
+namespace mapp {
 
 class dummy_mutex{
 public:


### PR DESCRIPTION
A new file has been added in utils/omp/compatibility.h.
Mini-apps should include this file instead of OpenMP's header: omp.h
This way, we avoid problems when OpenMP is not available on the machine.