### PR TITLE
 Improved Neuromapp's dependency handling (closes #63)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,15 @@ of coreneuron, 3 miniapps are available: kernel and solver
 * solver: This miniapp extracts the linear algbra solver of CoreNeuron, the Hines solver 
 	         (similar to Thomas Solver for 3 bands matrix)
 * cstep: It combines the kernel and the solver to mimic a step time of neuron simulator
+
+* queue: This miniapp simulates the queueing system of CoreNeuron.
  
 ##hello
 
 This directory provides an example of how could be design a miniapp (C++)
+
+You can disable the compilation of this mini-app by using the following variable in cmake
+command: '-DNEUROMAPP_DISABLE_HELLO=TRUE'
 
 ## neuromapp/iobench
 
@@ -35,6 +40,9 @@ the parameter configuration is more flexible.
 
 For more information, run the mini-app with the --help argument.
 
+You can disable the compilation of this mini-app by using the following variable in cmake
+command: '-DNEUROMAPP_DISABLE_IOBENCH=TRUE'
+
 ## neuromapp/keyvalue
 
 This directory contains a miniapp that mimics CoreNeuron simulation loop but outputs 
@@ -44,11 +52,8 @@ cases are defined in order to fill 25%, 50% or 75% of the main memory of a BG/Q 
 
 For more information, run the mini-app with the --help argument.
 
-## neuromapp/queuing
-	 
-This directory contains a miniapp that simulates the queueing system of CoreNeuron.
-
-Moreover the hello directory provides informations to create a new miniapp
+You can disable the compilation of this mini-app by using the following variable in cmake
+command: '-DNEUROMAPP_DISABLE_KEYVALUE=TRUE'
 
 ## neuromapp/replib
 
@@ -58,7 +63,23 @@ provides several options to distribute data across ranks in different ways.
 
 For more information, run the mini-app with the --help argument.
 
+You can disable the compilation of this mini-app by using the following variable in cmake
+command: '-DNEUROMAPP_DISABLE_REPLIB=TRUE'
+
 ## neuromapp/nest/synapse
 
 This directory contains a miniapp that simulates synapse models from NEST.
+
+You can disable the compilation of this mini-app by using the following variable in cmake
+command: '-DNEUROMAPP_DISABLE_NEST=TRUE'
+
+
+## Dependency Handling
+The following variables can be set in the cmake command to disable the compilation of certain 
+parts of the framework or ignore certain external libraries that would be used otherwise:
+'-DNEUROMAPP_DISABLE_HDF5MAPP=TRUE': Ignore the code under neuromapp/hdf5
+'-DNEUROMAPP_DISABLE_CASSANDRA=TRUE': Do not try to find the Cassandra installation
+'-DNEUROMAPP_DISABLE_CEPH=TRUE': Do not try to find the CEPH installation
+'-DNEUROMAPP_DISABLE_LEVELDB=TRUE': Do not try to find the LevelDB installation
+'-DNEUROMAPP_DISABLE_SKV=TRUE': Do not try to find the IBM SKV installation
 

--- a/README.md
+++ b/README.md
@@ -77,9 +77,14 @@ command: '-DNEUROMAPP_DISABLE_NEST=TRUE'
 ## Dependency Handling
 The following variables can be set in the cmake command to disable the compilation of certain 
 parts of the framework or ignore certain external libraries that would be used otherwise:
+
 '-DNEUROMAPP_DISABLE_HDF5MAPP=TRUE': Ignore the code under neuromapp/hdf5
+
 '-DNEUROMAPP_DISABLE_CASSANDRA=TRUE': Do not try to find the Cassandra installation
+
 '-DNEUROMAPP_DISABLE_CEPH=TRUE': Do not try to find the CEPH installation
+
 '-DNEUROMAPP_DISABLE_LEVELDB=TRUE': Do not try to find the LevelDB installation
+
 '-DNEUROMAPP_DISABLE_SKV=TRUE': Do not try to find the IBM SKV installation
 

--- a/neuromapp/app/CMakeLists.txt
+++ b/neuromapp/app/CMakeLists.txt
@@ -2,24 +2,97 @@ include_directories(${PROJECT_BINARY_DIR})
 include_directories(${PROJECT_SOURCE_DIR})
 
 add_executable (app driver.cpp main.cpp)
+
+# Hello mini-app
+if(NEUROMAPP_HELLO_MAPP)
+    target_link_libraries (app
+                           hello)
+    add_definitions(-DNEUROMAPP_HELLO_MAPP=1)
+    message(STATUS "Adding hello mini-app")
+else()
+    add_definitions(-DNEUROMAPP_HELLO_MAPP=0)
+    message(STATUS "Ignoring hello mini-app")
+endif()
+
+# Nest mini-apps
+if(NEUROMAPP_NEST_MAPP)
+    target_link_libraries (app
+                           nest_synapse
+                           nest_h5import_driver)
+    add_definitions(-DNEUROMAPP_NEST_MAPP=1)
+    message(STATUS "Adding Nest mini-apps")
+else()
+    add_definitions(-DNEUROMAPP_NEST_MAPP=0)
+    message(STATUS "Ignoring Nest mini-apps")
+endif()
+
+# HDF5 mini-app
+if(NEUROMAPP_HDF5_MAPP)
+    target_link_libraries (app
+                           h5read_driver)
+    add_definitions(-DNEUROMAPP_HDF5_MAPP=1)
+    message(STATUS "Adding HDF5 mini-app")
+else()
+    add_definitions(-DNEUROMAPP_HDF5_MAPP=0)
+    message(STATUS "Ignoring HDF5 mini-app")
+endif()
+
+# CoreNeuron mini-apps
+#if(NEUROMAPP_CORENEURON_MAPP)
+    target_link_libraries (app
+                           coreneuron10_kernel
+                           coreneuron10_solver
+                           coreneuron10_cstep
+                           coreneuron10_event
+                           coreneuron10_queue
+                           storage)
+#    add_definitions(-DNEUROMAPP_CORENEURON_MAPP=1)
+    message(STATUS "Adding CoreNeuron mini-apps")
+#else()
+#    add_definitions(-DNEUROMAPP_CORENEURON_MAPP=0)
+#    message(STATUS "Ignoring CoreNeuron mini-apps")
+#endif()
+
+# Keyvalue mini-app
+if(NEUROMAPP_KEYVALUE_MAPP)
+    target_link_libraries (app
+                           keyvalue)
+    add_definitions(-DNEUROMAPP_KEYVALUE_MAPP=1)
+    message(STATUS "Adding keyvalue mini-app")
+else()
+    add_definitions(-DNEUROMAPP_KEYVALUE_MAPP=0)
+    message(STATUS "Ignoring keyvalue mini-app")
+endif()
+
+# Replib mini-app
+if(NEUROMAPP_REPLIB_MAPP)
+    target_link_libraries (app
+                           replib)
+    add_definitions(-DNEUROMAPP_REPLIB_MAPP=1)
+    message(STATUS "Adding replib mini-app")
+else()
+    add_definitions(-DNEUROMAPP_REPLIB_MAPP=0)
+    message(STATUS "Ignoring replib mini-app")
+endif()
+
+# Iobench mini-app
+if(NEUROMAPP_IOBENCH_MAPP)
+    target_link_libraries (app
+                           iobench)
+    add_definitions(-DNEUROMAPP_IOBENCH_MAPP=1)
+    message(STATUS "Adding iobench mini-app")
+else()
+    add_definitions(-DNEUROMAPP_IOBENCH_MAPP=0)
+    message(STATUS "Ignoring iobench mini-app")
+endif()
+
+# Other needed libraries
 target_link_libraries (app
-                       hello
-                       keyvalue
-                       coreneuron10_kernel
-                       coreneuron10_solver
-                       coreneuron10_cstep
-                       coreneuron10_event
-                       nest_synapse
-                       nest_h5import_driver
-                       h5read_driver
-                       coreneuron10_queue
-                       replib
-                       storage
-                       iobench
                        ${READLINE_LIBRARY}
                        ${CURSES_CURSES_LIBRARY}
                        ${Boost_PROGRAM_OPTIONS_LIBRARIES}
                        ${Boost_CHRONO_LIBRARIES}
                        ${Boost_SYSTEM_LIBRARIES}
                        ${Boost_ATOMIC_LIBRARIES})
+
 install (TARGETS app DESTINATION bin)

--- a/neuromapp/app/main.cpp
+++ b/neuromapp/app/main.cpp
@@ -37,7 +37,7 @@
     #include <readline/history.h>
 #endif
 
-#include "app/miniapp.h" // the list of the miniapp API
+#include "app/miniapp.h" // the list of the available mini-apps
 #include "app/driver.h"
 #include "app/driver_exception.h"
 #include "utils/argv_data.h"
@@ -59,18 +59,7 @@ int compute(const mapp::driver& d, int argc, char * const argv[]){
 int main(int argc, char * const argv[]){
 
      mapp::driver d;
-     d.insert("hello",hello_execute);
-     d.insert("synapse", nest::model_execute);
-     d.insert("nest_h5import", nest::h5import::execute);
-     d.insert("h5read", hdf5::h5read::execute);
-     d.insert("event",event_execute);
-     d.insert("kernel",coreneuron10_kernel_execute);
-     d.insert("solver",coreneuron10_solver_execute);
-     d.insert("cstep",coreneuron10_cstep_execute);
-     d.insert("keyvalue",keyvalue_execute);
-     d.insert("replib",replib_execute);
-     d.insert("iobench",iobench_execute);
-     d.insert("queue",coreneuron10_queue_execute);
+     mapp::register_miniapps(d);
 
      //direct run
      if(argv[1] != NULL)

--- a/neuromapp/app/miniapp.h
+++ b/neuromapp/app/miniapp.h
@@ -2,6 +2,8 @@
  * Neuromapp - miniapp.h, Copyright (c), 2015,
  * Timothee Ewart - Swiss Federal Institute of technology in Lausanne,
  * timothee.ewart@epfl.ch,
+ * Judit Planas - Swiss Federal Institute of technology in Lausanne,
+ * judit.planas@epfl.ch,
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or
@@ -20,24 +22,82 @@
 
 /**
  * @file neuromapp/app/miniapp.h
- * \brief all include
+ * \brief File containing the list of enabled mini-apps to register in the driver
  */
 
 #ifndef MAPP_APP_
 #define MAPP_APP_
 
+
+#if NEUROMAPP_HELLO_MAPP
 #include "hello/hello.h"
+#endif
+
+#if NEUROMAPP_NEST_MAPP
 #include "nest/drivers/synapse.h"
 #include "nest/drivers/h5import.h"
+#endif
+
+#if NEUROMAPP_HDF5_MAPP
 #include "hdf5/drivers/h5read.h"
-#include "keyvalue/keyvalue.h"
+#endif
+
+//#if NEUROMAPP_CORENEURON_MAPP
 #include "coreneuron_1.0/event_passing/drivers/drivers.h"
 #include "coreneuron_1.0/kernel/kernel.h"
 #include "coreneuron_1.0/solver/solver.h"
 #include "coreneuron_1.0/cstep/cstep.h"
-#include "coreneuron_1.0/cstep/cstep.h"
 #include "coreneuron_1.0/queue/queue.h"
+//#endif
+
+#if NEUROMAPP_KEYVALUE_MAPP
+#include "keyvalue/keyvalue.h"
+#endif
+
+#if NEUROMAPP_REPLIB_MAPP
 #include "replib/replib.h"
+#endif
+
+#if NEUROMAPP_IOBENCH_MAPP
 #include "iobench/iobench.h"
+#endif
+
+#include "app/driver.h"
+
+//! Generic namespace for all the mini-apps
+namespace mapp{
+
+void register_miniapps(mapp::driver &d) {
+
+#if NEUROMAPP_HELLO_MAPP
+    d.insert("hello",hello_execute);
+#endif
+#if NEUROMAPP_NEST_MAPP
+    d.insert("synapse", nest::model_execute);
+    d.insert("nest_h5import", nest::h5import::execute);
+#endif
+#if NEUROMAPP_HDF5_MAPP
+    d.insert("h5read", hdf5::h5read::execute);
+#endif
+//#if NEUROMAPP_CORENEURON_MAPP
+    d.insert("event",event_execute);
+    d.insert("kernel",coreneuron10_kernel_execute);
+    d.insert("solver",coreneuron10_solver_execute);
+    d.insert("cstep",coreneuron10_cstep_execute);
+    d.insert("queue",coreneuron10_queue_execute);
+//#endif
+#if NEUROMAPP_KEYVALUE_MAPP
+    d.insert("keyvalue",keyvalue_execute);
+#endif
+#if NEUROMAPP_REPLIB_MAPP
+    d.insert("replib",replib_execute);
+#endif
+#if NEUROMAPP_IOBENCH_MAPP
+    d.insert("iobench",iobench_execute);
+#endif
+
+}
+
+} // namespace mapp
 
 #endif

--- a/neuromapp/coreneuron_1.0/CMakeLists.txt
+++ b/neuromapp/coreneuron_1.0/CMakeLists.txt
@@ -1,54 +1,64 @@
-include_directories(${PROJECT_BINARY_DIR})
-include_directories(${PROJECT_SOURCE_DIR})
+# Use -DNEUROMAPP_DISABLE_CORENEURON=TRUE to disable compilation/installation of this mini-app
+# Other mini-apps depend on some parts of these mini-apps, enabling them by now until
+# mini-apps are decoupled
+#if(NOT NEUROMAPP_DISABLE_CORENEURON)
+    include_directories(${PROJECT_BINARY_DIR})
+    include_directories(${PROJECT_SOURCE_DIR})
 
-#generate the file for the in put, create in the build directory
-configure_file("${PROJECT_SOURCE_DIR}/neuromapp/coreneuron_1.0/common/data/path.h.in"
-               "${PROJECT_BINARY_DIR}/neuromapp/coreneuron_1.0/common/data/path.h")
-
-
-add_library (coreneuron10_common STATIC
-            common/memory/nrnthread.c
-            common/memory/memory.c
-            common/util/nrnthread_handler.c
-            common/util/timer.c
-            common/data/helper.cpp)
+    #generate the file for the in put, create in the build directory
+    configure_file("${PROJECT_SOURCE_DIR}/neuromapp/coreneuron_1.0/common/data/path.h.in"
+                   "${PROJECT_BINARY_DIR}/neuromapp/coreneuron_1.0/common/data/path.h")
 
 
-add_library (coreneuron10_kernel STATIC
-            kernel/helper.c
-            kernel/mechanism/NaTs2_t.c
-            kernel/mechanism/ProbAMPANMDA_EMS.c
-            kernel/mechanism/Ih.c
-            kernel/main.c)
+    add_library (coreneuron10_common STATIC
+                 common/memory/nrnthread.c
+                 common/memory/memory.c
+                 common/util/nrnthread_handler.c
+                 common/util/timer.c
+                 common/data/helper.cpp)
 
 
-add_library (coreneuron10_solver STATIC
-             solver/helper.c
-             solver/hines.c
-             solver/main.c)
+    add_library (coreneuron10_kernel STATIC
+                 kernel/helper.c
+                 kernel/mechanism/NaTs2_t.c
+                 kernel/mechanism/ProbAMPANMDA_EMS.c
+                 kernel/mechanism/Ih.c
+                 kernel/main.c)
 
-add_library (coreneuron10_cstep STATIC
-             cstep/helper.c
-             cstep/main.c)
 
-add_library (coreneuron10_queue STATIC
-             queue/main.cpp)
+    add_library (coreneuron10_solver STATIC
+                 solver/helper.c
+                 solver/hines.c
+                 solver/main.c)
 
-target_link_libraries(coreneuron10_cstep coreneuron10_kernel coreneuron10_common) 
+    add_library (coreneuron10_cstep STATIC
+                 cstep/helper.c
+                 cstep/main.c)
 
-install (TARGETS coreneuron10_kernel coreneuron10_solver coreneuron10_cstep
-                 coreneuron10_common coreneuron10_queue DESTINATION lib)
+    add_library (coreneuron10_queue STATIC
+                 queue/main.cpp)
 
-install (FILES  kernel/mechanism/mechanism.h
-                kernel/kernel.h
-                solver/solver.h
-                cstep/cstep.h
-                common/data/helper.h
-                queue/tool/bin_queue.hpp
-                queue/tool/bin_queue.ipp
-                queue/tool/sptq_queue.hpp
-                queue/tool/sptq_queue.ipp
-                queue/tool/algorithm.h
-                DESTINATION include)
+    target_link_libraries(coreneuron10_cstep coreneuron10_kernel coreneuron10_common) 
 
-add_subdirectory (event_passing)
+    install (TARGETS coreneuron10_kernel coreneuron10_solver coreneuron10_cstep
+                     coreneuron10_common coreneuron10_queue DESTINATION lib)
+
+    install (FILES  kernel/mechanism/mechanism.h
+                    kernel/kernel.h
+                    solver/solver.h
+                    cstep/cstep.h
+                    common/data/helper.h
+                    queue/tool/bin_queue.hpp
+                    queue/tool/bin_queue.ipp
+                    queue/tool/sptq_queue.hpp
+                    queue/tool/sptq_queue.ipp
+                    queue/tool/algorithm.h
+                    DESTINATION include)
+
+    add_subdirectory (event_passing)
+
+#    set(NEUROMAPP_CORENEURON_MAPP ON CACHE BOOL "True if coreneuron mini-apps will be installed")
+#else()
+#    set(NEUROMAPP_CORENEURON_MAPP OFF CACHE BOOL "True if coreneuron mini-apps will be installed")
+#endif()
+

--- a/neuromapp/hdf5/CMakeLists.txt
+++ b/neuromapp/hdf5/CMakeLists.txt
@@ -1,18 +1,51 @@
-include_directories(${PROJECT_BINARY_DIR})
-include_directories(${PROJECT_SOURCE_DIR})
+# Use -DNEUROMAPP_DISABLE_HDF5MAPP=TRUE to disable compilation/installation of this mini-app
+if(NOT NEUROMAPP_DISABLE_HDF5MAPP)
+    # Check HDF5 version
+    set(HDF5_OK OFF)
+    if (HDF5_FOUND)
+        if (HDF5_VERSION)
+            if(HDF5_VERSION VERSION_LESS "1.8.0" AND NOT NEUROMAPP_DISABLE_HDF5MAPP)
+                message(STATUS "Some mini-apps require HDF5 version 1.8.0 or greater, but found version ${HDF5_VERSION}, ignoring them (HDF5 mini-app)")
+            else()
+                set(HDF5_OK ON)
+            endif()
+        else()
+            set(HDF5_OK ON)
+            message(STATUS "HDF5 version could not be determined, HDF5-dependent mini-apps may fail (HDF5 mini-app)")
+        endif()
+    else()
+        message(STATUS "HDF5 needed by some mini-apps, but HDF5 not found, ignoring them (HDF5 mini-app)")
+    endif()
 
+    if (HDF5_OK)
+        include_directories(${PROJECT_BINARY_DIR})
+        include_directories(${PROJECT_SOURCE_DIR})
 
-add_subdirectory(drivers)
-add_subdirectory(data)
+        add_subdirectory(drivers)
+        add_subdirectory(data)
 
-add_library(h5read h5reader.cpp )
+        add_library(h5read h5reader.cpp )
 
-target_link_libraries (h5read
-                       ${MPI_CXX_LIBRARIES}
-                       ${MPI_C_LIBRARIES}
-                       ${Boost_LIBRARIES}
-                       ${HDF5_LIBRARIES})
+        target_link_libraries (h5read
+                               ${MPI_CXX_LIBRARIES}
+                               ${MPI_C_LIBRARIES}
+                               ${Boost_LIBRARIES}
+                               ${HDF5_LIBRARIES})
 
-target_include_directories(h5read PRIVATE ${HDF5_INCLUDE_DIRS})
+        target_include_directories(h5read PRIVATE ${HDF5_INCLUDE_DIRS})
 
-install (TARGETS h5read DESTINATION lib)
+        install (TARGETS h5read DESTINATION lib)
+
+        set(NEUROMAPP_HDF5_MAPP ON CACHE BOOL "True if HDF5 mini-app will be installed")
+    else()
+        set(NEUROMAPP_HDF5_MAPP OFF CACHE BOOL "True if HDF5 mini-app will be installed")
+    endif()
+else()
+    # HDF5 data needed by Nest mini-apps, check it must be installed
+    if(NOT NEUROMAPP_DISABLE_NEST)
+        add_subdirectory(data)
+    endif()
+
+    set(NEUROMAPP_HDF5_MAPP OFF CACHE BOOL "True if HDF5 mini-app will be installed")
+endif()
+

--- a/neuromapp/hello/CMakeLists.txt
+++ b/neuromapp/hello/CMakeLists.txt
@@ -1,4 +1,11 @@
-add_library (hello main.cpp)
+# Use -DNEUROMAPP_DISABLE_HELLO=TRUE to disable compilation/installation of this mini-app
+if(NOT NEUROMAPP_DISABLE_HELLO)
+    add_library (hello main.cpp)
 
-install (TARGETS hello DESTINATION lib)
-install (FILES hello.h DESTINATION include)
+    install (TARGETS hello DESTINATION lib)
+    install (FILES hello.h DESTINATION include)
+
+    set(NEUROMAPP_HELLO_MAPP ON CACHE BOOL "True if hello mini-app will be installed")
+else()
+    set(NEUROMAPP_HELLO_MAPP OFF CACHE BOOL "True if hello mini-app will be installed")
+endif()

--- a/neuromapp/iobench/CMakeLists.txt
+++ b/neuromapp/iobench/CMakeLists.txt
@@ -1,59 +1,64 @@
-set(MPI_STATIC ON)
-find_package(MPI)
+# Use -DNEUROMAPP_DISABLE_IOBENCH=TRUE to disable compilation/installation of this mini-app
+if(NOT NEUROMAPP_DISABLE_IOBENCH)
+    set(MPI_STATIC ON)
+    find_package(MPI)
 
-if(MPI_FOUND)
-    include_directories(${MPI_INCLUDE_PATH})
-endif()
+    if(MPI_FOUND)
+        include_directories(${MPI_INCLUDE_PATH})
+    endif()
 
-include_directories(${PROJECT_BINARY_DIR})
-include_directories(${PROJECT_SOURCE_DIR})
+    include_directories(${PROJECT_BINARY_DIR})
+    include_directories(${PROJECT_SOURCE_DIR})
 
-#Add iobench to the mini-app library
-add_library (iobench main.cpp)
+    #Add iobench to the mini-app library
+    add_library (iobench main.cpp)
 
-install (TARGETS iobench DESTINATION lib)
-install (FILES iobench.h DESTINATION include)
+    install (TARGETS iobench DESTINATION lib)
+    install (FILES iobench.h DESTINATION include)
 
-# LevelDB backend
-find_package(Leveldb)
-if (${LEVELDB_FOUND})
-    include_directories(${LEVELDB_INCLUDE_DIRS})
-    add_definitions(-DIO_LDB)
+    # LevelDB backend
+    find_package(Leveldb)
+    if (${LEVELDB_FOUND})
+        include_directories(${LEVELDB_INCLUDE_DIRS})
+        add_definitions(-DIO_LDB)
 
-    install (FILES backends/leveldb.h DESTINATION include)
+        install (FILES backends/leveldb.h DESTINATION include)
+    else()
+        set(LEVELDB_LIBRARIES "")
+    endif()
+
+    # Cassandra backend
+    find_package(Cassandra)
+    if (${CASSANDRA_FOUND})
+        include_directories(${CASSANDRA_INCLUDE_DIRS})
+        add_definitions(-DIO_CASS -DCASS_USE_OPENSSL -D_GNU_SOURCE)
+
+        set(CASSANDRA_LIBRARIES ${CASSANDRA_LIBRARIES} "-lssl -lcrypto")
+
+        install (FILES backends/cassandra.h DESTINATION include)
+    else()
+        set(CASSANDRA_LIBRARIES "")
+    endif()
+
+    # OMP executable
+    add_executable(iobench-omp iobench.cpp benchmark.cpp)
+    target_link_libraries (iobench-omp ${LEVELDB_LIBRARIES} ${CASSANDRA_LIBRARIES} ${Boost_PROGRAM_OPTIONS_LIBRARIES})
+
+    if(MPI_FOUND)
+        # MPI+OMP executable (add -DIO_MPI to compile flags)
+        add_executable(MPI_Exec_io iobench.cpp benchmark.cpp)
+        set_target_properties(MPI_Exec_io PROPERTIES
+            COMPILE_FLAGS "${MPI_C_COMPILE_FLAGS} ${MPI_CXX_COMPILE_FLAGS} -DIO_MPI")
+        # Adding MPI_LIBRARIES adds also the -Bdynamic flag, which makes execution crash on BG/Q
+        target_link_libraries (MPI_Exec_io ${LEVELDB_LIBRARIES} ${CASSANDRA_LIBRARIES} ${MPI_CXX_LIBRARIES} ${Boost_PROGRAM_OPTIONS_LIBRARIES})
+    endif()
+
+    install (TARGETS iobench-omp DESTINATION bin)
+    if(MPI_FOUND)
+        install (TARGETS MPI_Exec_io DESTINATION bin)
+    endif()
+
+    set(NEUROMAPP_IOBENCH_MAPP ON CACHE BOOL "True if iobench mini-app will be installed")
 else()
-    set(LEVELDB_LIBRARIES "")
+    set(NEUROMAPP_IOBENCH_MAPP OFF CACHE BOOL "True if iobench mini-app will be installed")
 endif()
-
-# Cassandra backend
-find_package(Cassandra)
-if (${CASSANDRA_FOUND})
-    include_directories(${CASSANDRA_INCLUDE_DIRS})
-    add_definitions(-DIO_CASS -DCASS_USE_OPENSSL -D_GNU_SOURCE)
-
-    set(CASSANDRA_LIBRARIES ${CASSANDRA_LIBRARIES} "-lssl -lcrypto")
-
-    install (FILES backends/cassandra.h DESTINATION include)
-else()
-    set(CASSANDRA_LIBRARIES "")
-endif()
-
-# OMP executable
-add_executable(iobench-omp iobench.cpp benchmark.cpp)
-target_link_libraries (iobench-omp ${LEVELDB_LIBRARIES} ${CASSANDRA_LIBRARIES} ${Boost_PROGRAM_OPTIONS_LIBRARIES})
-
-if(MPI_FOUND)
-    # MPI+OMP executable (add -DIO_MPI to compile flags)
-    add_executable(MPI_Exec_io iobench.cpp benchmark.cpp)
-    set_target_properties(MPI_Exec_io PROPERTIES
-        COMPILE_FLAGS "${MPI_C_COMPILE_FLAGS} ${MPI_CXX_COMPILE_FLAGS} -DIO_MPI")
-    # Adding MPI_LIBRARIES adds also the -Bdynamic flag, which makes execution crash on BG/Q
-    target_link_libraries (MPI_Exec_io ${LEVELDB_LIBRARIES} ${CASSANDRA_LIBRARIES} ${MPI_CXX_LIBRARIES} ${Boost_PROGRAM_OPTIONS_LIBRARIES})
-endif()
-
-
-install (TARGETS iobench-omp DESTINATION bin)
-if(MPI_FOUND)
-    install (TARGETS MPI_Exec_io DESTINATION bin)
-endif()
-

--- a/neuromapp/keyvalue/CMakeLists.txt
+++ b/neuromapp/keyvalue/CMakeLists.txt
@@ -1,69 +1,79 @@
-set(MPI_STATIC ON)
-find_package(MPI REQUIRED )
+# Use -DNEUROMAPP_DISABLE_KEYVALUE=TRUE to disable compilation/installation of this mini-app
+if(NOT NEUROMAPP_DISABLE_KEYVALUE)
+    set(MPI_STATIC ON)
+    find_package(MPI)
 
-include_directories(${MPI_INCLUDE_PATH})
+    if (MPI_FOUND)
+        include_directories(${MPI_INCLUDE_PATH})
 
-include_directories(${PROJECT_BINARY_DIR})
-include_directories(${PROJECT_SOURCE_DIR})
+        include_directories(${PROJECT_BINARY_DIR})
+        include_directories(${PROJECT_SOURCE_DIR})
 
-# Add keyvalue to the mini-app library
-add_library (keyvalue main.cpp)
+        # Add keyvalue to the mini-app library
+        add_library (keyvalue main.cpp)
 
-install (TARGETS keyvalue DESTINATION lib)
-install (FILES keyvalue.h DESTINATION include)
+        install (TARGETS keyvalue DESTINATION lib)
+        install (FILES keyvalue.h DESTINATION include)
 
-# STL MAP backend
-add_library (map_store map/map_store.cpp)
-set(MAP_MAPP_LIBRARY "map_store")
+        # STL MAP backend
+        add_library (map_store map/map_store.cpp)
+        set(MAP_MAPP_LIBRARY "map_store")
 
-install (TARGETS map_store DESTINATION lib)
-install (FILES map/map_store.h DESTINATION include)
+        install (TARGETS map_store DESTINATION lib)
+        install (FILES map/map_store.h DESTINATION include)
 
-# SKV IBM backend
-find_package(Skv)
-if (${SKV_FOUND})
-    include_directories(${SKV_INCLUDE_DIRS})
-    add_definitions(-DSKV_STORE)
+        # SKV IBM backend
+        find_package(Skv)
+        if (${SKV_FOUND})
+            include_directories(${SKV_INCLUDE_DIRS})
+            add_definitions(-DSKV_STORE)
 
-    add_library(skv_store skv/skv_store.cpp)
-    set_target_properties(skv_store PROPERTIES
-                      LINK_FLAGS "${SKV_LIBRARIES}")
+            add_library(skv_store skv/skv_store.cpp)
+            set_target_properties(skv_store PROPERTIES
+                                  LINK_FLAGS "${SKV_LIBRARIES}")
 
-    install (TARGETS skv_store DESTINATION lib)
-    install (FILES skv/skv_store.h DESTINATION include)
+            install (TARGETS skv_store DESTINATION lib)
+            install (FILES skv/skv_store.h DESTINATION include)
 
-    set(SKV_MAPP_LIBRARY "skv_store")
+            set(SKV_MAPP_LIBRARY "skv_store")
+        else()
+            set(SKV_MAPP_LIBRARY "")
+            set(SKV_LIBRARIES "")
+        endif()
+
+        # CEPH - Rados backend
+        find_package(Ceph)
+        if (${CEPH_FOUND})
+            include_directories(${CEPH_INCLUDE_DIRS})
+            add_definitions(-DCEPH_STORE)
+
+            add_library(ceph_store ceph/ceph_store.cpp)
+            set_target_properties(ceph_store PROPERTIES
+                                  LINK_FLAGS "${CEPH_LIBRARIES}")
+
+            install (TARGETS ceph_store DESTINATION lib)
+            install (FILES ceph/ceph_store.h DESTINATION include)
+
+            set(CEPH_MAPP_LIBRARY "ceph_store")
+        else()
+            set(CEPH_MAPP_LIBRARY "")
+            set(CEPH_LIBRARIES "")
+        endif()
+
+        add_executable(MPI_Exec_kv utils/statistic.cpp mpiexec.cpp )
+
+        # Adding MPI_LIBRARIES adds also the -Bdynamic flag, which makes execution crash on BG/Q, use MPI_CXX_LIBRARIES as a workaround
+        set(MPI_LIBRARIES ${MPI_LIBRARY} ${MPI_EXTRA_LIBRARY})
+        # SKV_LINK_FLAGS must go after SKV_LIBRARIES
+        target_link_libraries (MPI_Exec_kv ${MAP_MAPP_LIBRARY} ${SKV_MAPP_LIBRARY} ${SKV_LIBRARIES} ${CEPH_MAPP_LIBRARY} ${CEPH_LIBRARIES} ${MPI_CXX_LIBRARIES})
+
+        install (TARGETS MPI_Exec_kv DESTINATION bin)
+
+        set(NEUROMAPP_KEYVALUE_MAPP ON CACHE BOOL "True if keyvalue mini-app will be installed")
+    else()
+        set(NEUROMAPP_KEYVALUE_MAPP OFF CACHE BOOL "True if keyvalue mini-app will be installed")
+        message(STATUS "MPI needed by some mini-apps, but MPI not found, ignoring them (keyvalue mini-app)")
+    endif()
 else()
-    set(SKV_MAPP_LIBRARY "")
-    set(SKV_LIBRARIES "")
+    set(NEUROMAPP_KEYVALUE_MAPP OFF CACHE BOOL "True if keyvalue mini-app will be installed")
 endif()
-
-
-# CEPH - Rados backend
-find_package(Ceph)
-if (${CEPH_FOUND})
-    include_directories(${CEPH_INCLUDE_DIRS})
-    add_definitions(-DCEPH_STORE)
-
-    add_library(ceph_store ceph/ceph_store.cpp)
-    set_target_properties(ceph_store PROPERTIES
-                      LINK_FLAGS "${CEPH_LIBRARIES}")
-
-    install (TARGETS ceph_store DESTINATION lib)
-    install (FILES ceph/ceph_store.h DESTINATION include)
-
-    set(CEPH_MAPP_LIBRARY "ceph_store")
-else()
-    set(CEPH_MAPP_LIBRARY "")
-    set(CEPH_LIBRARIES "")
-endif()
-
-add_executable(MPI_Exec_kv utils/statistic.cpp mpiexec.cpp )
-
-# Adding MPI_LIBRARIES adds also the -Bdynamic flag, which makes execution crash on BG/Q, use MPI_CXX_LIBRARIES as a workaround
-set(MPI_LIBRARIES ${MPI_LIBRARY} ${MPI_EXTRA_LIBRARY})
-# SKV_LINK_FLAGS must go after SKV_LIBRARIES
-target_link_libraries (MPI_Exec_kv ${MAP_MAPP_LIBRARY} ${SKV_MAPP_LIBRARY} ${SKV_LIBRARIES} ${CEPH_MAPP_LIBRARY} ${CEPH_LIBRARIES} ${MPI_CXX_LIBRARIES})
-
-install (TARGETS MPI_Exec_kv DESTINATION bin)
-

--- a/neuromapp/nest/CMakeLists.txt
+++ b/neuromapp/nest/CMakeLists.txt
@@ -1,5 +1,34 @@
-include_directories(${HDF5_INCLUDE_DIRS})
+# Use -DNEUROMAPP_DISABLE_NEST=TRUE to disable compilation/installation of this mini-app
+if(NOT NEUROMAPP_DISABLE_NEST)
+    # Check HDF5 version
+    set(HDF5_OK OFF)
+    if (HDF5_FOUND)
+        if (HDF5_VERSION)
+            if(HDF5_VERSION VERSION_LESS "1.8.0" AND NOT NEUROMAPP_DISABLE_HDF5MAPP)
+                message(STATUS "Some mini-apps require HDF5 version 1.8.0 or greater, but found version ${HDF5_VERSION}, ignoring them (Nest mini-app)")
+            else()
+                set(HDF5_OK ON)
+            endif()
+        else()
+            set(HDF5_OK ON)
+            message(STATUS "HDF5 version could not be determined, HDF5-dependent mini-apps may fail (Nest mini-app)")
+        endif()
+    else()
+        message(STATUS "HDF5 needed by some mini-apps, but HDF5 not found, ignoring them (Nest mini-app)")
+    endif()
 
-add_subdirectory (drivers)
-add_subdirectory (h5import)
-add_subdirectory (nestkernel)
+    if (HDF5_OK)
+        include_directories(${HDF5_INCLUDE_DIRS})
+
+        add_subdirectory (drivers)
+        add_subdirectory (h5import)
+        add_subdirectory (nestkernel)
+
+        set(NEUROMAPP_NEST_MAPP ON CACHE BOOL "True if Nest mini-apps will be installed")
+    else()
+        set(NEUROMAPP_NEST_MAPP OFF CACHE BOOL "True if Nest mini-apps will be installed")
+    endif()
+else()
+    set(NEUROMAPP_NEST_MAPP OFF CACHE BOOL "True if Nest mini-apps will be installed")
+endif()
+

--- a/neuromapp/replib/CMakeLists.txt
+++ b/neuromapp/replib/CMakeLists.txt
@@ -1,24 +1,35 @@
-set(MPI_STATIC ON)
-find_package(MPI REQUIRED)
+# Use -DNEUROMAPP_DISABLE_REPLIB=TRUE to disable compilation/installation of this mini-app
+if(NOT NEUROMAPP_DISABLE_REPLIB)
+    set(MPI_STATIC ON)
+    find_package(MPI REQUIRED)
 
-include_directories(${MPI_INCLUDE_PATH})
+    if (MPI_FOUND)
+        include_directories(${MPI_INCLUDE_PATH})
 
-include_directories(${PROJECT_BINARY_DIR})
-include_directories(${PROJECT_SOURCE_DIR})
+        include_directories(${PROJECT_BINARY_DIR})
+        include_directories(${PROJECT_SOURCE_DIR})
 
-#Add replib to the mini-app library
-add_library (replib main.cpp)
+        #Add replib to the mini-app library
+        add_library (replib main.cpp)
 
-install (TARGETS replib DESTINATION lib)
-install (FILES replib.h DESTINATION include)
+        install (TARGETS replib DESTINATION lib)
+        install (FILES replib.h DESTINATION include)
 
-add_executable(MPI_Exec_rl utils/statistics.cpp utils/tools.cpp mpiexec.cpp )
+        add_executable(MPI_Exec_rl utils/statistics.cpp utils/tools.cpp mpiexec.cpp )
 
-# Adding MPI_LIBRARIES adds also the -Bdynamic flag, which makes execution crash on BG/Q
-target_link_libraries (MPI_Exec_rl ${MPI_CXX_LIBRARIES})
+        # Adding MPI_LIBRARIES adds also the -Bdynamic flag, which makes execution crash on BG/Q
+        target_link_libraries (MPI_Exec_rl ${MPI_CXX_LIBRARIES})
 
-set_target_properties(MPI_Exec_rl PROPERTIES
-		COMPILE_FLAGS "${MPI_C_COMPILE_FLAGS} ${MPI_CXX_COMPILE_FLAGS}")
+        set_target_properties(MPI_Exec_rl PROPERTIES
+		                      COMPILE_FLAGS "${MPI_C_COMPILE_FLAGS} ${MPI_CXX_COMPILE_FLAGS}")
 
+        install (TARGETS MPI_Exec_rl DESTINATION bin)
 
-install (TARGETS MPI_Exec_rl DESTINATION bin)
+        set(NEUROMAPP_REPLIB_MAPP ON CACHE BOOL "True if replib mini-app will be installed")
+    else()
+        set(NEUROMAPP_REPLIB_MAPP OFF CACHE BOOL "True if replib mini-app will be installed")
+        message(STATUS "MPI needed by some mini-apps, but MPI not found, ignoring them (replib mini-app)")
+    endif()
+else()
+    set(NEUROMAPP_REPLIB_MAPP OFF CACHE BOOL "True if replib mini-app will be installed")
+endif()

--- a/neuromapp/utils/argv_data.h
+++ b/neuromapp/utils/argv_data.h
@@ -81,7 +81,7 @@ struct argv_data {
         if (argc<0) throw std::logic_error("argv_data: negative argc");
 
         // argv_.size()==argc+1.
-        if (argv_.size()!=1+argc) throw std::logic_error("argv_data: argv_ vector size mismatch");
+        if ((int)argv_.size()!=1+argc) throw std::logic_error("argv_data: argv_ vector size mismatch");
 
         // argv[i] should be non-zero for i=0..(argc-1), and point to within argv_buf.
         char *argv_buf_begin=&argv_buf[0];

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,11 +8,29 @@ if(NOT Boost_USE_STATIC_LIBS)
 	add_definitions(-DBOOST_TEST_DYN_LINK=TRUE)
 endif()
 
-add_subdirectory (coreneuron_1.0)
-add_subdirectory (hello)
-add_subdirectory (iobench)
 add_subdirectory (utils)
 add_subdirectory (app)
-add_subdirectory (keyvalue)
-add_subdirectory (hdf5)
-add_subdirectory (nest)
+
+if(NEUROMAPP_CORENEURON_MAPP)
+    add_subdirectory (coreneuron_1.0)
+endif()
+
+if(NEUROMAPP_HELLO_MAPP)
+    add_subdirectory (hello)
+endif()
+
+if(NEUROMAPP_IOBENCH_MAPP)
+    add_subdirectory (iobench)
+endif()
+
+if(NEUROMAPP_KEYVALUE_MAPP)
+    add_subdirectory (keyvalue)
+endif()
+
+if(NEUROMAPP_HDF5_MAPP)
+    add_subdirectory (hdf5)
+endif()
+
+if(NEUROMAPP_NEST_MAPP)
+    add_subdirectory (nest)
+endif()


### PR DESCRIPTION
Neuromapp now tries to handle dependencies a bit better and silently ignore
those mini-apps that depend on external libraries not found in the system.
In addition, there are new CMake variables to manually disable the compilation
of certain mini-apps or the detection of external libraries.
Finally, README has been updated explaining these changes.