### PR TITLE
Major changes in replib mini-app

### DIFF
--- a/neuromapp/replib/CMakeLists.txt
+++ b/neuromapp/replib/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Use -DNEUROMAPP_DISABLE_REPLIB=TRUE to disable compilation/installation of this mini-app
 if(NOT NEUROMAPP_DISABLE_REPLIB)
     set(MPI_STATIC ON)
-    find_package(MPI REQUIRED)
+    find_package(MPI)
 
     if (MPI_FOUND)
         include_directories(${MPI_INCLUDE_PATH})
@@ -11,14 +11,17 @@ if(NOT NEUROMAPP_DISABLE_REPLIB)
 
         #Add replib to the mini-app library
         add_library (replib main.cpp)
-
         install (TARGETS replib DESTINATION lib)
         install (FILES replib.h DESTINATION include)
 
-        add_executable(MPI_Exec_rl utils/statistics.cpp utils/tools.cpp mpiexec.cpp )
+        # Add statistics as a separate library
+        add_library (replib-stats utils/statistics.cpp utils/tools.cpp)
+        install (TARGETS replib-stats DESTINATION lib)
+
+        add_executable(MPI_Exec_rl mpiexec.cpp )
 
         # Adding MPI_LIBRARIES adds also the -Bdynamic flag, which makes execution crash on BG/Q
-        target_link_libraries (MPI_Exec_rl ${MPI_CXX_LIBRARIES})
+        target_link_libraries (MPI_Exec_rl replib-stats ${MPI_CXX_LIBRARIES})
 
         set_target_properties(MPI_Exec_rl PROPERTIES
 		                      COMPILE_FLAGS "${MPI_C_COMPILE_FLAGS} ${MPI_CXX_COMPILE_FLAGS}")

--- a/neuromapp/replib/README.md
+++ b/neuromapp/replib/README.md
@@ -23,8 +23,8 @@ as follows:
 2) Run test:
 
 ```
-    for "s" reporting_steps {
-        for 10 iterations {
+    for "r" reporting_steps {
+        for "s" simulation_steps {
             simulate_computing_phase(sleep)
             create_data_in_bufferToFill
         }
@@ -64,8 +64,10 @@ Here's a more detailed description:
     with some degree of randomness, the block size of each process. This option 
     only applies when data distribution is generated randomly 
     (``` --write rnd1b ```) options (default, 10).
-* --steps, -s [int]: Number of reporting steps. 1 reporting step happens every 10 
-    simulation steps (default, 1)
+* --sim-steps, -s [int]: Number of simulation steps for each reporting step 
+    (default, 15)
+* --rep-steps, -r [int]: Number of reporting steps. 1 reporting step happens every 
+    'sim-steps' simulation steps (default, 1)
 * --time, -t [int]: Amount of time (in ms) spent in 1 simulation step (default, 100)
 * --check, -c: If present, verify the output report was correctly written 
     (no check by default)
@@ -79,9 +81,9 @@ Some other relevant information for this mini-app:
   order to better understand this parameters, the user must be aware of the following 
   concepts:
  * The real report file is structured as an array, where:
-    - Each item contains the information of all cells for one reporting time step:
+    - Each item contains the information of all cells for one simulation time step:
 
-      | rep_time_step_1 | rep_time_step_2 | rep_time_step_3 | ...
+      | sim_time_step_1 | sim_time_step_2 | sim_time_step_3 | ...
 
     - Each time step contains the information for each cell. Cells are always ordered 
       in the same way for all time steps, and the order criteria is their GID (integer):
@@ -91,7 +93,7 @@ Some other relevant information for this mini-app:
     - Each cell contains the information about its cell compartments. There is one float 
       value (voltage) for each compartment and a cell can hold a maximum of 350 
       compartments. When using the ``` --write rnd1b ``` option, the number of 
-      compartments per cell is computed randomly with a lower bound of 200 and an upper 
+      compartments per cell is computed randomly with a lower bound of 100 and an upper 
       bound of 350:
 
       | voltage_comp_1 | voltage_comp_2 | voltage_comp_3 | ...
@@ -99,10 +101,14 @@ Some other relevant information for this mini-app:
     - Thus, the write size per process cannot be computed in advance and is reported by 
       the mini-app at the end of the execution (per reporting step).
 
+    - In this case, the frequency of writing data to disk depends on the 
+      ``` --sim-steps S ``` parameter. ``` S ``` simulation time steps will be grouped 
+      together as one single block and will be written to disk at once.
+
 * If a data distribution file is used to configure the mini-app execution, the amount 
   of cells is then ignored and the block sizes read from the data distribution file 
   are used instead. In this case, the amount of data written per process can be easily 
-  derived from the data distribution file and the number of reporting steps.
-
-
+  derived from the data distribution file and the number of reporting steps. In this 
+  case, the ``` --sim-steps S ``` parameter is only used to simulate the computing 
+  phase.
 

--- a/neuromapp/replib/benchmark.h
+++ b/neuromapp/replib/benchmark.h
@@ -26,6 +26,7 @@
 #include <mpi.h>
 #include <unistd.h>
 #include <string.h>
+#include <iomanip>
 
 
 #include "replib/utils/tools.h"
@@ -37,194 +38,212 @@
 
 #include "utils/mpi/timer.h"
 
+namespace replib {
+
 class benchmark {
-public:
-    /** \fun benchmark(int argc, char* argv[])
+
+    private:
+        /** config structure with the benchmark parameters*/
+        replib::config c_;
+        replib::fileview * f_;
+
+        /** \fun init()
+            \brief initialize the object */
+        void init() {
+            if (c_.write() == "file1b") {
+                f_ = file1b(c_);
+            } else if (c_.write() == "fileNb") {
+                f_ = fileNb(c_);
+            } else { // "rnd1b"
+                f_ = rnd1b(c_);
+            }
+        }
+
+    public:
+        /** \fun benchmark(int argc, char* argv[])
         \brief create the benchmark and initialize it according to the
         given parameters
-     */
-    benchmark(int argc, char* argv[]) : c_(argc, argv), f_(NULL) {
-        init();
-    }
+         */
+        benchmark(int argc, char* const argv[]) : c_(argc, argv), f_(NULL) {
+            init();
+        }
 
-    /** \fun benchmark()
+        /** \fun benchmark()
         \brief create the benchmark and initialize it with default values
-     */
-    benchmark() : c_() {
-        init();
-    }
+         */
+        benchmark() : c_() {
+            init();
+        }
 
-    ~benchmark() {
-        delete(f_);
-    }
+        ~benchmark() {
+            delete(f_);
+        }
 
-    /** \fun get_config() const
+        /** \fun get_config() const
         \brief return the configuration */
-    replib::config const & get_config() const {
-        return c_;
-    }
+        replib::config const & get_config() const {
+            return c_;
+        }
 
-    /** \fun get_config()
+        /** \fun get_config()
         \brief return the configuration */
-    replib::config & get_config() {
-        return c_;
-    }
+        replib::config & get_config() {
+            return c_;
+        }
 
-    /** \fun get_fileview() const
+        /** \fun get_fileview() const
         \brief return the fileview */
-    replib::fileview const & get_fileview() const {
-        return *f_;
-    }
+        replib::fileview const & get_fileview() const {
+            return *f_;
+        }
 
-    /** \fun get_fileview()
+        /** \fun get_fileview()
         \brief return the fileview */
-    replib::fileview & get_fileview() {
-        return *f_;
-    }
-
-private:
-    /** config structure with the benchmark parameters*/
-    replib::config c_;
-    replib::fileview * f_;
-
-    /** \fun init()
-        \brief initialize the object */
-    void init() {
-        if (c_.write() == "file1b") {
-            f_ = file1b(c_);
-        } else if (c_.write() == "fileNb") {
-            f_ = fileNb(c_);
-        } else { // "rnd1b"
-            f_ = rnd1b(c_);
-        }
-    }
-};
-
-/** \fun replib::statistics run_benchmark (benchmark & b)
-    \brief Run the benchmark and return the object with the
-    recorded statistics
- */
-replib::statistics run_benchmark (benchmark & b) {
-
-    // Double buffering
-    unsigned int sizeToWrite = b.get_fileview().total_bytes();
-
-    // Data is written to file every 10 reporting steps
-    int reportToDisk = 10;
-    sizeToWrite *= reportToDisk;
-
-    float * buffer1 = (float *) malloc(sizeToWrite);
-    float * buffer2 = (float *) malloc(sizeToWrite);
-
-    memset(buffer1, 0, sizeToWrite);
-    memset(buffer2, 0, sizeToWrite);
-
-    float * bufferToFill = &buffer1[0];
-    float * bufferToWrite = &buffer2[0];
-
-    //Open the file
-    MPI_File fh;
-    char * report = strdup(b.get_config().output_report().c_str());
-    int error = MPI_File_open(MPI_COMM_WORLD, report, MPI_MODE_WRONLY | MPI_MODE_CREATE, MPI_INFO_NULL, &fh);
-    if (error != MPI_SUCCESS) {
-        std::cout << "[" << b.get_config().id() << "] Error opening file" << std::endl;
-        MPI_Abort(MPI_COMM_WORLD, 911);
-    }
-
-    b.get_fileview().set_fileview(&fh);
-
-    // ReportingLib writes data to disk every 10 reporting steps
-    int stepsToWrite = reportToDisk;
-    int nwrites = 0;
-    int compCount = sizeToWrite / sizeof(float); // Represents the number of compartments
-    double compTimeUs = b.get_config().sim_time_ms() * 1000;
-    double start, end, elapsed;
-
-    std::vector<double> welapsed;
-    welapsed.reserve(b.get_config().rep_steps());
-
-    mapp::timer t;
-    int steps = b.get_config().rep_steps() * reportToDisk;
-
-    start = MPI_Wtime();
-    for( int i = 0; i < steps; i++ ) {
-        // Rewrite vector
-        for (int j = i%10; j < compCount; j += 10) {
-            bufferToFill[j] = (float) b.get_config().id() * 1000.0 + (float) nwrites
-                    + (float) ( ((float) ((j%1000) + 1.0)) / 1000.0);
+        replib::fileview & get_fileview() {
+            return *f_;
         }
 
-        if (stepsToWrite == 1) {
-            end = MPI_Wtime();
-            elapsed = (end - start) * 1e6; // us
-
-            // The I/O write will happen in the next iteration, sleep to simulate
-            // processing time
-            int sleep = compTimeUs - elapsed;
-            usleep( (sleep > 0) ? sleep : 0 );
+        /** \fun success()
+        \brief return whether the execution of this benchmark succeeded or failed */
+        bool success() const {
+            return c_.passed();
         }
 
-        stepsToWrite--;
+        /** \fun replib::statistics run_benchmark ()
+        \brief Run the benchmark and return the object with the
+        recorded statistics */
+        replib::statistics run_benchmark ()
+        {
+            // Double buffering
+            unsigned int sizeToWrite = f_->total_bytes();
 
-        //std::stringstream ss1;
-        //ss1 << "[" << b.get_config().id() << "] [it" << i << "] Vector: ";
-        //for (int s = 0; s < compCount; s++) {
-        //    ss1 << std::fixed << std::setprecision(4) << bufferToFill[s] << " ";
-        //}
-        //ss1 << std::endl;
-        //std::cout << mapp::mpi_filter_all() << ss1.str();
+            float * buffer1 = (float *) malloc(sizeToWrite);
+            float * buffer2 = (float *) malloc(sizeToWrite);
 
-        if (stepsToWrite == 0) {
-            // Account time spent in MPI write
-            start = MPI_Wtime();
+            memset(buffer1, 0, sizeToWrite);
+            memset(buffer2, 0, sizeToWrite);
 
-            // Swap buffers
-            float * tmp = bufferToFill;
-            bufferToFill = bufferToWrite;
-            bufferToWrite = tmp;
+            float * bufferToFill = &buffer1[0];
+            float * bufferToWrite = &buffer2[0];
 
-            //std::cout << "[" << 0 << "] --------------------- Writing out data ---------------------" << std::endl;
-
-            MPI_Status status;
-            t.tic();
-            error = MPI_File_write_all(fh, bufferToWrite, compCount, MPI_FLOAT, &status);
-            t.toc();
-
-            welapsed.push_back(t.time());
-
+            //Open the file
+            MPI_File fh;
+            char * report = strdup(c_.output_report().c_str());
+            int error = MPI_File_open(MPI_COMM_WORLD, report, MPI_MODE_WRONLY | MPI_MODE_CREATE, MPI_INFO_NULL, &fh);
             if (error != MPI_SUCCESS) {
-                std::cout << "[" << b.get_config().id() << "] Error writing file" << std::endl;
-                MPI_Abort(MPI_COMM_WORLD, 915);
+                std::cout << "[" << c_.id() << "] Error opening file" << std::endl;
+                MPI_Abort(MPI_COMM_WORLD, 911);
             }
 
-            //std::cout << "[" << mpiRank << "] --------------------- Data written ---------------------" << std::endl;
+            f_->set_fileview(&fh);
 
-            // Ignore time spent in MPI write
-            //start = MPI_Wtime();
+            int nwrites = 0;
+            int compCount = sizeToWrite / sizeof(float); // Represents the number of compartments
+            double compTimeUs = c_.sim_time_ms() * 1000;
 
-            stepsToWrite = reportToDisk;
-            nwrites++;
+            std::vector<double> welapsed;
+            welapsed.reserve(c_.rep_steps());
+
+            // Timer used to compute the time spent inside MPI I/O collective only
+            mapp::timer t_io;
+
+            // Timer used to simulation the computational phase
+            mapp::timer t_comp;
+
+            // Number of reporting steps
+            int rep_steps = c_.rep_steps();
+
+            // Number of simulation steps for each reporting step
+            int sim_steps = c_.sim_steps();
+
+            t_comp.tic();
+            for (int i = 0; i < rep_steps; i++) {
+                // Simulate computational phase
+                for (int j = 0; j < sim_steps; j++) {
+                    // Rewrite vector to avoid caching everything
+                    for (int k = j%sim_steps; k < compCount; k += sim_steps) {
+                        bufferToFill[k] = (float) c_.id() * 1000.0 + (float) nwrites
+                                + (float) (((float) ((k%1000) + 1.0)) / 1000.0);
+                    }
+                }
+                t_comp.toc();
+
+                // Complete computational phase with sleep
+                double elapsed = t_comp.time() * 1e6; // elapsed in us
+                int sleep = compTimeUs - elapsed;
+                usleep( (sleep > 0) ? sleep : 0 );
+
+                //std::stringstream ss1;
+                //ss1 << "[" << c_.id() << "] [it" << i << "] Vector: ";
+                //for (int s = 0; s < compCount; s++) {
+                //    ss1 << std::fixed << std::setprecision(4) << bufferToFill[s] << " ";
+                //}
+                //ss1 << std::endl;
+                //std::cout << mapp::mpi_filter_all() << ss1.str() << mapp::mpi_filter_master();
+
+                // Uncomment to account time spent by MPI write in t_comp as well and comment corresponding line below
+                t_comp.tic();
+
+                // Swap buffers
+                float * tmp = bufferToFill;
+                bufferToFill = bufferToWrite;
+                bufferToWrite = tmp;
+
+                //std::cout << "[" << 0 << "] --------------------- Writing out data ---------------------" << std::endl;
+
+                MPI_Status status;
+                // t_io only counts time spent in MPI_File_write_all to compute I/O statistics
+                t_io.tic();
+                error = MPI_File_write_all(fh, bufferToWrite, compCount, MPI_FLOAT, &status);
+                t_io.toc();
+
+                //std::stringstream ss2;
+                //ss2 << "[" << c_.id() << "] [it" << i << "] size = " << compCount * sizeof(float)
+                //<< " bytes ; time = " << t_io.time() << " seconds" << std::endl;
+                //std::cout << mapp::mpi_filter_all() << ss2.str() << mapp::mpi_filter_master();
+
+                welapsed.push_back(t_io.time());
+
+                if (error != MPI_SUCCESS) {
+                    std::cout << "[" << c_.id() << "] Error writing file" << std::endl;
+                    MPI_Abort(MPI_COMM_WORLD, 915);
+                }
+
+                //std::cout << "[" << mpiRank << "] --------------------- Data written ---------------------" << std::endl;
+
+                // Uncomment to ignore time spent in MPI write and comment corresponding line above
+                //t_comp.tic();
+
+                nwrites++;
+            }
+            MPI_Barrier(MPI_COMM_WORLD);
+
+            error = MPI_File_close(&fh);
+            if (error != MPI_SUCCESS) {
+                std::cout << "[" << c_.id() << "] Error closing file" << std::endl;
+                MPI_Abort(MPI_COMM_WORLD, 912);
+            }
+
+            free(buffer1);
+            free(buffer2);
+
+            MPI_Barrier(MPI_COMM_WORLD);
+            if (c_.check()) {
+                int passed = 0;
+                if (c_.id() == 0) {
+                    c_.passed() = check_report(report, nwrites, c_.elems_per_step(), c_.procs());
+                    passed = c_.passed() ? 1 : 0;
+                }
+                MPI_Bcast(&passed, 1, MPI_INT, 0, MPI_COMM_WORLD);
+                c_.passed() = (passed == 1) ? true : false;
+            }
+
+            replib::statistics s(c_, f_->total_bytes(), welapsed);
+
+            return s;
         }
-    }
-    MPI_Barrier(MPI_COMM_WORLD);
+};
 
-    error = MPI_File_close(&fh);
-    if (error != MPI_SUCCESS) {
-        std::cout << "[" << b.get_config().id() << "] Error closing file" << std::endl;
-        MPI_Abort(MPI_COMM_WORLD, 912);
-    }
-
-    free(buffer1);
-    free(buffer2);
-
-    MPI_Barrier(MPI_COMM_WORLD);
-    if (b.get_config().check() && b.get_config().id() == 0) {
-        replib::check_report(report, nwrites, b.get_config().elems_per_step() * reportToDisk, b.get_config().procs());
-    }
-
-    replib::statistics s(b.get_config(), b.get_fileview().total_bytes(), welapsed);
-
-    return s;
-}
+} // end namespace
 
 #endif

--- a/neuromapp/replib/main.cpp
+++ b/neuromapp/replib/main.cpp
@@ -55,9 +55,15 @@ int replib_help(int argc, char* const argv[], po::variables_map& vm){
     ("file,f", po::value<std::string>()->default_value(""), "[string] Path to the file with write distribution per process")
 
     ("invert,i", "Invert the rank ID, only applies when reading distribution from file (fileXX)")
+
     ("numcells,c", po::value<int>()->default_value(10), "[int] Number of cells, only applies when creating random write distribution (rndXX)")
-    ("steps,s", po::value<int>()->default_value(1), "[int] Number of reporting steps (1 reporting step every 10 simulation steps)")
+
+    ("sim-steps,s", po::value<int>()->default_value(15), "[int] Number of simulation steps for each reporting step")
+
+    ("rep-steps,r", po::value<int>()->default_value(1), "[int] Number of reporting steps (1 reporting step happens every 'sim-steps' simulation steps)")
+
     ("time,t", po::value<int>()->default_value(100), "[int] Amount of time spent in 1 simulation step (in ms)")
+
     ("check,v", "Verify the output report was correctly written");
 
     po::store(po::parse_command_line(argc, argv, desc), vm);
@@ -91,8 +97,13 @@ int replib_help(int argc, char* const argv[], po::variables_map& vm){
            return mapp::MAPP_BAD_ARG;
     }
 
-    if(vm["steps"].as<int>() < 1 ){
-        std::cout << "Error: steps must be at least 1." << std::endl;
+    if(vm["sim-steps"].as<int>() < 1 ){
+        std::cout << "Error: simulation steps must be at least 1." << std::endl;
+           return mapp::MAPP_BAD_ARG;
+    }
+
+    if(vm["rep-steps"].as<int>() < 1 ){
+        std::cout << "Error: reporting steps must be at least 1." << std::endl;
            return mapp::MAPP_BAD_ARG;
     }
 
@@ -123,14 +134,15 @@ void replib_content(po::variables_map const& vm){
     std::string f(vm["file"].as<std::string>());
     bool inv = !(vm["invert"].empty());
     int nc = vm["numcells"].as<int>();
-    int steps = vm["steps"].as<int>();
+    int ssteps = vm["sim-steps"].as<int>();
+    int rsteps = vm["rep-steps"].as<int>();
     int t = vm["time"].as<int>();
     bool check = !(vm["check"].empty());
 
     command << launcher_helper::mpi_launcher() << " -n " << np << " " << path
             << "MPI_Exec_rl  -w " << wr << " -o " << o << ((f == "") ? "" : " -f ") << f
-            << " " << (inv ? "-i" : "") << " " << " -nc " << nc << " -s " << steps
-            << " -t " << t << (check ? " -v" : "");
+            << " " << (inv ? "-i" : "") << " " << " -c " << nc << " -s " << ssteps
+            << " -r " << rsteps << " -t " << t << (check ? " -v" : "");
 
 	std::cout << "Running command: " << command.str() << std::endl;
 	system(command.str().c_str());

--- a/neuromapp/replib/mpiio_dist/common1b.h
+++ b/neuromapp/replib/mpiio_dist/common1b.h
@@ -37,7 +37,7 @@ namespace replib {
 inline fileview * common1b(config & c, unsigned int elemsToWrite) {
 
     // Number of elements to skip for this process
-    int offsetElems;
+    int offsetElems = 0;
 
     // Write buffer treated as a single block, so it's like we process a single cell
     c.numcells() = 1;

--- a/neuromapp/replib/mpiio_dist/file1b.h
+++ b/neuromapp/replib/mpiio_dist/file1b.h
@@ -42,7 +42,6 @@ namespace replib {
     then create the fileview object
  */
 inline fileview * file1b(config & c) {
-
     // Find the corresponding line in the file
     std::vector<std::string> row;
     read_row(c, row);

--- a/neuromapp/replib/utils/config.h
+++ b/neuromapp/replib/utils/config.h
@@ -47,26 +47,29 @@ private:
     std::string output_report_;
     bool        invert_;
     int         numcells_;
+    int         sim_steps_;
     int         rep_steps_;
     int         elems_per_step_;
     int         sim_time_ms_;
     bool        check_;
+    bool        passed_;
 
 public:
     /** \fn config(int argc = 0 , char * argv[] = NULL)
         \brief parse the command from argc and argv, the functor indicates the return type, I could
             write template and trait class, to do */
     explicit config (int argc = 0 , char * const argv[] = NULL) :
-            procs_(1), write_("rnd1b"), input_dist_(""), output_report_(""), invert_(false),
-            numcells_(10), rep_steps_(1), elems_per_step_(0), sim_time_ms_(100), check_(false) {
+            procs_(1), write_("rnd1b"), input_dist_(""), output_report_(""), invert_(false), numcells_(10),
+            sim_steps_(15), rep_steps_(1), elems_per_step_(0), sim_time_ms_(100), check_(false), passed_(false) {
         if (argc != 0) {
             std::vector<std::string> v(argv+1, argv+argc);
             argument_helper(v,"-w",write(),to_string());
             argument_helper(v,"-o",output_report(),to_string());
             argument_helper(v,"-f",input_dist(),to_string());
             argument_helper(v,"-i",invert(),to_true());
-            argument_helper(v,"-nc",numcells(),to_int());
-            argument_helper(v,"-s",rep_steps(),to_int());
+            argument_helper(v,"-c",numcells(),to_int());
+            argument_helper(v,"-s",sim_steps(),to_int());
+            argument_helper(v,"-r",rep_steps(),to_int());
             argument_helper(v,"-t",sim_time_ms(),to_int());
             argument_helper(v,"-v",check(),to_true());
         }
@@ -164,6 +167,13 @@ public:
     }
 
     /**
+     \brief return the number of simulation steps, read only
+     */
+    inline int sim_steps() const {
+        return sim_steps_;
+    }
+
+    /**
      \brief return the number of reporting steps, read only
      */
     inline int rep_steps() const {
@@ -189,6 +199,13 @@ public:
      */
     inline bool check() const {
         return check_;
+    }
+
+    /**
+     \brief return whether output report verification passed or failed, read only
+     */
+    inline bool passed() const {
+        return passed_;
     }
 
     /**
@@ -241,6 +258,13 @@ public:
      }
 
      /**
+      \brief return the number of simulation steps, write only
+      */
+     inline int& sim_steps() {
+         return sim_steps_;
+     }
+
+     /**
       \brief return the number of reporting steps, write only
       */
      inline int& rep_steps() {
@@ -268,6 +292,13 @@ public:
          return check_;
      }
 
+     /**
+      \brief return whether output report verification passed or failed, write only
+      */
+     inline bool& passed() {
+         return passed_;
+     }
+
     /** \brief the print function, I do not like friend function */
     void print(std::ostream& out) const {
         out << " procs: " << procs() << " \n"
@@ -276,9 +307,14 @@ public:
             << " output_report_: " << output_report() << " \n"
             << " invert_: " << invert() << " \n"
             << " numcells_: " << numcells() << " \n"
+            << " sim_steps_: " << sim_steps() << " \n"
             << " rep_steps_: " << rep_steps() << " \n"
             << " elems_per_step_: " << elems_per_step() << " \n"
-            << " sim_time_ms_: " << sim_time_ms() << " \n";
+            << " sim_time_ms_: " << sim_time_ms() << " \n"
+            << " check_: " << check() << " \n";
+        if (check()) {
+            out << "Report verification: " << ( passed() ? "PASSED" : "FAILED") << "\n";
+        }
     }
 };
 

--- a/neuromapp/replib/utils/statistics.h
+++ b/neuromapp/replib/utils/statistics.h
@@ -48,12 +48,14 @@ class statistics {
             \brief create the statistics object
          */
         explicit statistics(replib::config const& conf = replib::config(),
-                unsigned int bytes = 0.0, std::vector<double> times = std::vector<double>()) :
+                unsigned int bytes = 0, std::vector<double> times = std::vector<double>()) :
                 c_(conf), bytes_(bytes), times_(times), g_mbw(0.), a_mbw(0.), max_(), min_() {}
 
         inline unsigned int bytes() const {return bytes_;}
         inline double mbw() const {return g_mbw;}
         inline double aggr_mbw() const {return a_mbw;}
+        inline const bw_stats& get_max() const { return max_; }
+        inline const bw_stats& get_min() const { return min_; }
         void process();
         void print(std::ostream& os) const;
 

--- a/neuromapp/replib/utils/tools.cpp
+++ b/neuromapp/replib/utils/tools.cpp
@@ -26,6 +26,7 @@
 #include <iomanip>
 #include <vector>
 #include <iostream>
+#include <sstream>
 #include <stdlib.h>
 #include <string.h>
 
@@ -94,7 +95,6 @@ bool replib::check_report (char * report, int nwrites, int repCycleElems, int mp
         memset(readValues, 0, readSize);
         mpioff = i * readSize;
         MPI_File_read_at(fh, mpioff, readValues, repCycleElems, MPI_FLOAT, &status);
-
         //std::cout << "----------------------------- Reading values for time step " << i << " -----------------------------" << std::endl;
         for (int s = 0; s < repCycleElems; s++) {
             float expected = (float) compsPerRank[pairIdx].first * 1000.0 + (float) i + (float) ((rankIdx[compsPerRank[pairIdx].first]%1000) + 1.0) / 1000.0;
@@ -127,6 +127,6 @@ bool replib::check_report (char * report, int nwrites, int repCycleElems, int mp
 
     free(readValues);
 
-    std::cout << "Report verification: " << ( (error == 0) ? "PASSED" : "FAILED") << std::endl;
+    //std::cout << "Report verification: " << ( (error == 0) ? "PASSED" : "FAILED") << std::endl;
     return (error == 0);
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -34,3 +34,7 @@ endif()
 if(NEUROMAPP_NEST_MAPP)
     add_subdirectory (nest)
 endif()
+
+if(NEUROMAPP_REPLIB_MAPP)
+    add_subdirectory (replib)
+endif()

--- a/test/iobench/args.cpp
+++ b/test/iobench/args.cpp
@@ -32,6 +32,8 @@
 #include <boost/test/unit_test.hpp>
 #include "iobench/utils/args.h"
 #include "utils/argv_data.h"
+// Get OMP header if available
+#include "utils/omp/compatibility.h"
 
 #ifdef IO_MPI
 //Performs MPI init/finalize
@@ -63,11 +65,7 @@ BOOST_AUTO_TEST_CASE(args_constructor_default_test){
 
     #pragma omp parallel
     {
-#ifdef _OPENMP
         threads = omp_get_num_threads();
-#else
-        threads = 1;
-#endif
     }
 
     BOOST_CHECK_EQUAL(a.procs(), procs);

--- a/test/iobench/stats.cpp
+++ b/test/iobench/stats.cpp
@@ -60,8 +60,8 @@ BOOST_AUTO_TEST_CASE(stats_killer_mpi_test){
     iobench::stats st;
 
     double times[8] = {3.5, 4.8, 2.9, 6.7, 3.9, 4.2, 5.3, 6.4};
-    double mb = 1024;
-    double ops = 2048;
+    double mb = 1024.;
+    double ops = 2048.;
 
     double avgb = 0.0, avgi = 0.0;
     for (int i = 0; i < 8; i++) {
@@ -69,8 +69,8 @@ BOOST_AUTO_TEST_CASE(stats_killer_mpi_test){
         avgb += mb / times[i];
         avgi += ops / times[i];
     }
-    avgb /= 8;
-    avgi /= 8;
+    avgb /= 8.;
+    avgi /= 8.;
     // Stddev and stderr are 0.0 because all ranks compute the same avg
     // (except when there is only 1 rank)
     // FIXME: introduce variability across ranks and compute this properly

--- a/test/replib/CMakeLists.txt
+++ b/test/replib/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_executable(rl-config config.cpp)
+target_link_libraries(rl-config ${Boost_LIBRARIES} ${MPI_C_LIBRARIES} ${MPI_CXX_LIBRARIES})
+add_mpi_test(rl-config)
+
+add_executable(rl-stats stats.cpp)
+target_link_libraries(rl-stats replib-stats ${Boost_LIBRARIES} ${MPI_C_LIBRARIES} ${MPI_CXX_LIBRARIES})
+add_mpi_test(rl-stats)
+
+add_executable(rl-bench bench.cpp ${PROJECT_SOURCE_DIR}/neuromapp/iobench/benchmark.cpp)
+target_link_libraries(rl-bench replib-stats ${Boost_LIBRARIES} ${MPI_C_LIBRARIES} ${MPI_CXX_LIBRARIES})
+add_mpi_test(rl-bench)

--- a/test/replib/bench.cpp
+++ b/test/replib/bench.cpp
@@ -1,5 +1,5 @@
 /*
- * Neuromapp - mpiexec.cpp, Copyright (c), 2015,
+ * Neuromapp - io-omp.cpp, Copyright (c), 2015,
  * Judit Planas - Swiss Federal Institute of technology in Lausanne,
  * judit.planas@epfl.ch,
  * All rights reserved.
@@ -12,29 +12,40 @@
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details..  See the GNU
- * Lesser General Public License for more details.
+ * GNU General Public License for more details. See
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library.
  */
 
-// Include the MPI version 2 C++ bindings:
-#include <mpi.h>
-#include <iostream>
-#include <stdlib.h>
+/**
+ * @file neuromapp/test/iobench/bench.cpp
+ *  General test on the iobench miniapp
+ */
+
+#define BOOST_TEST_MODULE replibBenchTEST
+
+#include <stdio.h>
+
+#include <boost/test/unit_test.hpp>
 
 #include "replib/benchmark.h"
-#include "replib/utils/statistics.h"
+#include "utils/argv_data.h"
 
-/** \fun main
-    \brief main program of the miniapp, run by MPI
- */
-int main(int argc, char* argv[]) {
-    // Build benchmark according to command line arguments
+
+BOOST_AUTO_TEST_CASE(iobench_test){
+    std::string s[14]={"binary", "-w", "rnd1b", "-o", "./currents.bbp", "-c", "1024", "-s",
+            "5", "-r", "15", "-t", "10", "-v"};
+
+    int narg=sizeof(s)/sizeof(s[0]);
+    mapp::argv_data A(s,s+narg);
+    int argc=A.argc();
+    char * const *argv=A.argv();
+
     replib::benchmark b(argc, argv);
-    replib::statistics s = b.run_benchmark();
-    s.process();
-    std::cout << s << std::endl;
-   return 0;
+    b.run_benchmark();
+
+    BOOST_CHECK_EQUAL(b.success(), true);
 }
+
+

--- a/test/replib/config.cpp
+++ b/test/replib/config.cpp
@@ -1,0 +1,139 @@
+/*
+ * Neuromapp - config.cpp, Copyright (c), 2015,
+ * Judit Planas - Swiss Federal Institute of technology in Lausanne,
+ * judit.planas@epfl.ch,
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details. See
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+
+/**
+ * @file neuromapp/test/replib/config.cpp
+ *  Test on the replib miniapp config class
+ */
+
+#define BOOST_TEST_MODULE replibConfigTEST
+
+#include <boost/test/unit_test.hpp>
+#include "replib/utils/config.h"
+#include "utils/argv_data.h"
+
+//Performs MPI init/finalize
+#include "test/tools/mpi_helper.h"
+
+BOOST_AUTO_TEST_CASE(config_constructor_default_test){
+    replib::config c;
+
+    int         procs = 1;
+    int         id = 0;
+    std::string write = "rnd1b";
+    std::string input_dist = "";
+    std::string output_report = "";
+    bool        invert = false;
+    int         numcells = 10;
+    int         sim_steps = 15;
+    int         rep_steps = 1;
+    int         elems_per_step = 0;
+    int         sim_time_ms = 100;
+    bool        check = false;
+    bool        passed = false;
+
+    MPI_Comm_size(MPI_COMM_WORLD, &procs);
+    MPI_Comm_rank(MPI_COMM_WORLD, &id);
+
+    BOOST_CHECK_EQUAL(c.procs(), procs);
+    BOOST_CHECK_EQUAL(c.id(), id);
+    BOOST_CHECK_EQUAL(c.write(), write);
+    BOOST_CHECK_EQUAL(c.input_dist(), input_dist);
+    BOOST_CHECK_EQUAL(c.output_report(), output_report);
+    BOOST_CHECK_EQUAL(c.invert(), invert);
+    BOOST_CHECK_EQUAL(c.numcells(), numcells);
+    BOOST_CHECK_EQUAL(c.sim_steps(), sim_steps);
+    BOOST_CHECK_EQUAL(c.rep_steps(), rep_steps);
+    BOOST_CHECK_EQUAL(c.elems_per_step(), elems_per_step);
+    BOOST_CHECK_EQUAL(c.sim_time_ms(), sim_time_ms);
+    BOOST_CHECK_EQUAL(c.check(), check);
+    BOOST_CHECK_EQUAL(c.passed(), passed);
+}
+
+
+BOOST_AUTO_TEST_CASE(config_constructor_test){
+    replib::config c;
+
+    std::string write = "file1b";
+    std::string input_dist = "./input.txt";
+    std::string output_report = "./output.txt";
+    bool        invert = true;
+    int         numcells = 200;
+    int         sim_steps = 6;
+    int         rep_steps = 19;
+    int         elems_per_step = 256;
+    int         sim_time_ms = 170;
+    bool        check = true;
+    bool        passed = true;
+
+    c.write() = write;
+    c.input_dist() = input_dist;
+    c.output_report() = output_report;
+    c.invert() = invert;
+    c.numcells() = numcells;
+    c.sim_steps() = sim_steps;
+    c.rep_steps() = rep_steps;
+    c.elems_per_step() = elems_per_step;
+    c.sim_time_ms() = sim_time_ms;
+    c.check() = check;
+    c.passed() = passed;
+
+    BOOST_CHECK_EQUAL(c.write(), write);
+    BOOST_CHECK_EQUAL(c.input_dist(), input_dist);
+    BOOST_CHECK_EQUAL(c.output_report(), output_report);
+    BOOST_CHECK_EQUAL(c.invert(), invert);
+    BOOST_CHECK_EQUAL(c.numcells(), numcells);
+    BOOST_CHECK_EQUAL(c.sim_steps(), sim_steps);
+    BOOST_CHECK_EQUAL(c.rep_steps(), rep_steps);
+    BOOST_CHECK_EQUAL(c.elems_per_step(), elems_per_step);
+    BOOST_CHECK_EQUAL(c.sim_time_ms(), sim_time_ms);
+    BOOST_CHECK_EQUAL(c.check(), check);
+    BOOST_CHECK_EQUAL(c.passed(), passed);
+}
+
+BOOST_AUTO_TEST_CASE(config_constructor_argv_test){
+    std::string s[17]={"binary", "-w", "fileNb", "-o", "/tmp/currents.bbp", "-f", "/tmp/input.txt",
+            "-i", "-c", "1024", "-s", "7", "-r", "100", "-t", "50", "-v"};
+
+    int narg=sizeof(s)/sizeof(s[0]);
+
+    mapp::argv_data A(s,s+narg);
+
+    int argc=A.argc();
+    char * const *argv=A.argv();
+
+    replib::config c(argc, argv);
+
+    c.procs() = 4;
+    c.id() = 3;
+
+    BOOST_CHECK_EQUAL(c.procs(), 4);
+    BOOST_CHECK_EQUAL(c.id(), 3);
+    BOOST_CHECK_EQUAL(c.write(), "fileNb");
+    BOOST_CHECK_EQUAL(c.input_dist(), "/tmp/input.txt");
+    BOOST_CHECK_EQUAL(c.output_report(), "/tmp/currents.bbp");
+    BOOST_CHECK_EQUAL(c.invert(), true);
+    BOOST_CHECK_EQUAL(c.numcells(), 1024);
+    BOOST_CHECK_EQUAL(c.sim_steps(), 7);
+    BOOST_CHECK_EQUAL(c.rep_steps(), 100);
+    BOOST_CHECK_EQUAL(c.sim_time_ms(), 50);
+    BOOST_CHECK_EQUAL(c.check(), true);
+    BOOST_CHECK_EQUAL(c.passed(), false);
+}

--- a/test/replib/stats.cpp
+++ b/test/replib/stats.cpp
@@ -1,0 +1,118 @@
+/*
+ * Neuromapp - stats.cpp, Copyright (c), 2015,
+ * Judit Planas - Swiss Federal Institute of technology in Lausanne,
+ * judit.planas@epfl.ch,
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details. See
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+
+/**
+ * @file neuromapp/test/replib/stats.cpp
+ *  Test on the replib miniapp statistics
+ */
+
+#define BOOST_TEST_MODULE replibStatsTEST
+
+#include <vector>
+
+#include <boost/test/unit_test.hpp>
+#include "replib/utils/statistics.h"
+#include "replib/utils/config.h"
+
+//Performs MPI init/finalize
+#include "test/tools/mpi_helper.h"
+
+struct double_int {
+    double d_; // rank's bandwidth
+    int i_;    // rank ID
+};
+
+BOOST_AUTO_TEST_CASE(stats_constructor_default_test){
+    replib::config c;
+    replib::statistics st(c, 0, std::vector<double>());
+
+    BOOST_CHECK_EQUAL(st.bytes(), 0);
+    BOOST_CHECK_CLOSE(st.mbw(), 0.0, 0.00001);
+    BOOST_CHECK_CLOSE(st.aggr_mbw(), 0.0, 0.00001);
+}
+
+BOOST_AUTO_TEST_CASE(stats_killer_mpi_test){
+    replib::config c;
+    c.numcells() = 512;
+    c.elems_per_step() = c.numcells() * 350;
+
+    unsigned int bytes = c.elems_per_step() * sizeof(float);
+
+    int mpi_size, mpi_rank;
+    MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &mpi_size);
+
+    double t[8] = {3.5, 4.8, 2.9, 6.7, 3.9, 4.2, 5.3, 6.4};
+    std::vector<double> times;
+    for (int i = 0; i < 8; i++) {
+        times.push_back((t[i] + (10 - mpi_rank)) / 10000.);
+    }
+
+    replib::statistics st(c, bytes, times);
+
+    // Compute average bw
+    double avgb = 0.0;
+    double mb = (double) bytes / (1024.*1024.);
+    for (unsigned int i = 0; i < times.size(); i++) {
+        avgb += mb / times[i];
+    }
+    avgb /= (double) times.size();
+
+    // Compute aggregated bw
+    double aggrb = 0.0;
+    MPI_Reduce(&avgb, &aggrb, 1, MPI_DOUBLE, MPI_SUM, 0, MPI_COMM_WORLD);
+
+    // Compute max and min ranks
+    double_int me, max, min;
+    me.d_ = avgb;
+    me.i_ = mpi_rank;
+    MPI_Reduce(&me, &max, 1, MPI_DOUBLE_INT, MPI_MAXLOC, 0, MPI_COMM_WORLD);
+    MPI_Reduce(&me, &min, 1, MPI_DOUBLE_INT, MPI_MINLOC, 0, MPI_COMM_WORLD);
+
+    replib::bw_stats max_st, min_st;
+    max_st.rank_ = max.i_;
+    max_st.size_ = bytes;
+    max_st.time_ = 0.0;
+    max_st.mbw_ = max.d_;
+    min_st.rank_ = min.i_;
+    min_st.size_ = bytes;
+    min_st.time_ = 0.0;
+    min_st.mbw_ = min.d_;
+
+    // Finally, compute average bw for one rank
+    // Rank's original avgb is needed to compute max & min, so do not overwrite until this point!
+    avgb = aggrb / (double) mpi_size;
+
+    st.process();
+
+    if (mpi_rank == 0) {
+        BOOST_CHECK_EQUAL(st.bytes(), bytes);
+        BOOST_CHECK_CLOSE(st.mbw(), avgb, 0.00001);
+        BOOST_CHECK_CLOSE(st.aggr_mbw(), aggrb, 0.00001);
+        BOOST_CHECK_EQUAL(st.get_max().rank_, max_st.rank_);
+        BOOST_CHECK_EQUAL(st.get_max().size_, max_st.size_);
+        BOOST_CHECK_CLOSE(st.get_max().time_, max_st.time_, 0.00001);
+        BOOST_CHECK_CLOSE(st.get_max().mbw_, max_st.mbw_, 0.00001);
+        BOOST_CHECK_EQUAL(st.get_min().rank_, min_st.rank_);
+        BOOST_CHECK_EQUAL(st.get_min().size_, min_st.size_);
+        BOOST_CHECK_CLOSE(st.get_min().time_, min_st.time_, 0.00001);
+        BOOST_CHECK_CLOSE(st.get_min().mbw_, min_st.mbw_, 0.00001);
+    }
+}


### PR DESCRIPTION
- Changed the frequency when the mini-app writes output reports to disk. This matches the current implementation of the real simulators. Now it's more intuitive, and can be easily changed (see README.md).
- Added tests.
- Improved makefile.
- Fixed verification mechanism to check whether the output report has been written correctly. This works now for any mini-app configuration.